### PR TITLE
Persist TCP/UDP connections and add web status indicator

### DIFF
--- a/firmware/components/um1_http_server/include/um1_http_server.h
+++ b/firmware/components/um1_http_server/include/um1_http_server.h
@@ -59,6 +59,7 @@ esp_err_t spiffs_get_handler(httpd_req_t *req);
 esp_err_t ws_control_handler(httpd_req_t *req);
 void send_uart_ws_data(int uart_port, const uint8_t *data, size_t len);
 esp_err_t reboot_handler(httpd_req_t *req);
+esp_err_t stream_status_handler(httpd_req_t *req);
 httpd_handle_t start_webserver(void);
 
 #endif // UM1_LAN_H

--- a/firmware/components/um1_http_server/um1_http_server.c
+++ b/firmware/components/um1_http_server/um1_http_server.c
@@ -38,6 +38,13 @@ httpd_uri_t config_get_uri = {
     .user_ctx = NULL
 };
 
+httpd_uri_t stream_status = {
+    .uri      = "/api/stream_status",
+    .method   = HTTP_GET,
+    .handler  = stream_status_handler,
+    .user_ctx = NULL
+};
+
 const httpd_uri_t config_save = {
     .uri       = "/config",
     .method    = HTTP_POST,
@@ -164,6 +171,19 @@ esp_err_t system_info_handler(httpd_req_t *req)
     free(out);
     cJSON_Delete(root);
 
+    return ESP_OK;
+}
+
+esp_err_t stream_status_handler(httpd_req_t *req)
+{
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "tcp", tcp_connected);
+    cJSON_AddBoolToObject(root, "udp", udp_connected);
+    char *out = cJSON_PrintUnformatted(root);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, out);
+    free(out);
+    cJSON_Delete(root);
     return ESP_OK;
 }
 
@@ -622,6 +642,7 @@ httpd_handle_t start_webserver(void)
         httpd_register_uri_handler(server, &system_info);
         httpd_register_uri_handler(server, &config_get_uri);
         httpd_register_uri_handler(server, &config_save);
+        httpd_register_uri_handler(server, &stream_status);
         httpd_register_uri_handler(server, &upload);
         httpd_register_uri_handler(server, &ota_update);
         httpd_register_uri_handler(server, &reboot);

--- a/firmware/components/um1_lan/start_lan.c
+++ b/firmware/components/um1_lan/start_lan.c
@@ -15,6 +15,7 @@
 #include "start_lan.h"
 #include "um1_lan.h"
 #include "um1_config.h"
+#include "um1_uart.h"
 
 static const char *TAG = "eth_if";
 
@@ -67,7 +68,8 @@ static void got_ip_event_handler(void *arg, esp_event_base_t event_base,
     }
     *ip_copy = *ip_info;
 
-	xTaskCreate(tcp_server_task, "tcp_server", 4096, ip_copy, tskIDLE_PRIORITY + 5, NULL);
+    init_stream_sockets();
+    xTaskCreate(tcp_server_task, "tcp_server", 4096, ip_copy, tskIDLE_PRIORITY + 5, NULL);
 }
 
 void start_lan(void)

--- a/firmware/components/um1_uart/include/um1_uart.h
+++ b/firmware/components/um1_uart/include/um1_uart.h
@@ -24,7 +24,11 @@
 void start_uart(void);
 void uart1_task(void *arg);
 void uart2_task(void *arg);
+void init_stream_sockets(void);
 void send_uart_packet_with_timestamp(int uart_port, const uint8_t *data, size_t len);
-void send_tcp_packet(const char *host, int port, int uart_port, const uint8_t *data, size_t len);
-void send_udp_packet(const char *host, int port, int uart_port, const uint8_t *data, size_t len);
+void send_tcp_packet(int uart_port, const uint8_t *data, size_t len);
+void send_udp_packet(int uart_port, const uint8_t *data, size_t len);
 uint64_t reverse_bytes_u64(uint64_t value);
+
+extern bool tcp_connected;
+extern bool udp_connected;

--- a/firmware/components/um1_uart/um1_uart.c
+++ b/firmware/components/um1_uart/um1_uart.c
@@ -2,6 +2,13 @@
 
 /*static const char *TAG = "um1_uart";*/
 
+static int tcp_sock = -1;
+static int udp_sock = -1;
+static struct sockaddr_in tcp_dest;
+static struct sockaddr_in udp_dest;
+bool tcp_connected = false;
+bool udp_connected = false;
+
 void start_uart(void){
 	um1_uart_config_t uart1_cfg = global_uart_config[0];
 	um1_uart_config_t uart2_cfg = global_uart_config[1];
@@ -102,12 +109,12 @@ void send_uart_packet_with_timestamp(int uart_port, const uint8_t *data, size_t 
 
     // TCP
     if (global_tcp_config.enabled) {
-        send_tcp_packet(global_tcp_config.server, global_tcp_config.port, uart_port, extended_buffer, total_len);
+        send_tcp_packet(uart_port, extended_buffer, total_len);
     }
 
     // UDP
     if (global_udp_config.enabled) {
-        send_udp_packet(global_udp_config.server, global_udp_config.port, uart_port, extended_buffer, total_len);
+        send_udp_packet(uart_port, extended_buffer, total_len);
     }
 
     // MQTT
@@ -119,43 +126,64 @@ void send_uart_packet_with_timestamp(int uart_port, const uint8_t *data, size_t 
     }
 }
 
-void send_tcp_packet(const char *host, int port, int uart_port, const uint8_t *data, size_t len) {
-    struct sockaddr_in dest;
-    int sock = socket(AF_INET, SOCK_STREAM, 0);
-    if (sock < 0) return;
-
-    dest.sin_family = AF_INET;
-    dest.sin_port = htons(port);
-    inet_pton(AF_INET, host, &dest.sin_addr);
-
-    if (connect(sock, (struct sockaddr *)&dest, sizeof(dest)) != 0) {
-        close(sock);
-        return;
+void init_stream_sockets(void) {
+    if (global_tcp_config.enabled) {
+        tcp_sock = socket(AF_INET, SOCK_STREAM, 0);
+        if (tcp_sock >= 0) {
+            tcp_dest.sin_family = AF_INET;
+            tcp_dest.sin_port = htons(global_tcp_config.port);
+            inet_pton(AF_INET, global_tcp_config.server, &tcp_dest.sin_addr);
+            if (connect(tcp_sock, (struct sockaddr *)&tcp_dest, sizeof(tcp_dest)) == 0) {
+                tcp_connected = true;
+            } else {
+                close(tcp_sock);
+                tcp_sock = -1;
+            }
+        }
     }
 
-    char buffer[BUF_SIZE + 16];
-    int offset = snprintf(buffer, sizeof(buffer), "uart%d:", uart_port);
-    if (offset + len > sizeof(buffer)) len = sizeof(buffer) - offset;
-    memcpy(buffer + offset, data, len);
-    send(sock, buffer, offset + len, 0);
-    close(sock);
+    if (global_udp_config.enabled) {
+        udp_sock = socket(AF_INET, SOCK_DGRAM, 0);
+        if (udp_sock >= 0) {
+            udp_dest.sin_family = AF_INET;
+            udp_dest.sin_port = htons(global_udp_config.port);
+            inet_pton(AF_INET, global_udp_config.server, &udp_dest.sin_addr);
+            if (connect(udp_sock, (struct sockaddr *)&udp_dest, sizeof(udp_dest)) == 0) {
+                udp_connected = true;
+            } else {
+                close(udp_sock);
+                udp_sock = -1;
+            }
+        }
+    }
 }
 
-void send_udp_packet(const char *host, int port, int uart_port, const uint8_t *data, size_t len) {
-    struct sockaddr_in dest;
-    int sock = socket(AF_INET, SOCK_DGRAM, 0);
-    if (sock < 0) return;
-
-    dest.sin_family = AF_INET;
-    dest.sin_port = htons(port);
-    inet_pton(AF_INET, host, &dest.sin_addr);
+void send_tcp_packet(int uart_port, const uint8_t *data, size_t len) {
+    if (!tcp_connected) return;
 
     char buffer[BUF_SIZE + 16];
     int offset = snprintf(buffer, sizeof(buffer), "uart%d:", uart_port);
     if (offset + len > sizeof(buffer)) len = sizeof(buffer) - offset;
     memcpy(buffer + offset, data, len);
-    sendto(sock, buffer, offset + len, 0, (struct sockaddr *)&dest, sizeof(dest));
-    close(sock);
+    if (send(tcp_sock, buffer, offset + len, 0) < 0) {
+        close(tcp_sock);
+        tcp_sock = -1;
+        tcp_connected = false;
+    }
+}
+
+void send_udp_packet(int uart_port, const uint8_t *data, size_t len) {
+    if (!udp_connected) return;
+
+    char buffer[BUF_SIZE + 16];
+    int offset = snprintf(buffer, sizeof(buffer), "uart%d:", uart_port);
+    if (offset + len > sizeof(buffer)) len = sizeof(buffer) - offset;
+    memcpy(buffer + offset, data, len);
+    if (send(udp_sock, buffer, offset + len, 0) < 0) {
+        close(udp_sock);
+        udp_sock = -1;
+        udp_connected = false;
+    }
 }
 
 uint64_t reverse_bytes_u64(uint64_t value) {

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -35,6 +35,7 @@
         <label><input type="checkbox" id="uart1" /> uart1</label>
         <label><input type="checkbox" id="uart2" /> uart2</label>
       </div>
+      <div id="server_status" class="server-status" style="display:none;"></div>
     </div>
     <div id="log" class="stream-output"></div>
   </div>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,6 +1,7 @@
 const logDiv = document.getElementById("log");
 let ws;
 let pendingReboot = false;
+let statusInterval;
 
 function start_socket() {
   ws = new WebSocket(`ws://${location.host}/ws`);
@@ -31,6 +32,19 @@ function log(msg) {
 
   logDiv.appendChild(line);
   logDiv.scrollTop = logDiv.scrollHeight;
+}
+
+function updateServerStatus() {
+  fetch('/api/stream_status')
+    .then(r => r.json())
+    .then(s => {
+      const el = document.getElementById('server_status');
+      if (!el) return;
+      const connected = s.tcp || s.udp;
+      el.textContent = `TCP: ${s.tcp ? 'подключен' : 'нет'}, UDP: ${s.udp ? 'подключен' : 'нет'}`;
+      el.className = 'server-status ' + (connected ? 'connected' : 'disconnected');
+    })
+    .catch(_ => {});
 }
 
 function loadSidebar() {
@@ -137,4 +151,17 @@ async function sendReboot() {
 
 document.addEventListener("DOMContentLoaded", () => {
   if (!pendingReboot) start_socket();
+  fetch('/api/config')
+    .then(r => r.json())
+    .then(cfg => {
+      if (cfg.tcp.enabled || cfg.udp.enabled) {
+        const st = document.getElementById('server_status');
+        if (st) {
+          st.style.display = 'block';
+          updateServerStatus();
+          statusInterval = setInterval(updateServerStatus, 5000);
+        }
+      }
+    })
+    .catch(_ => {});
 });

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -142,3 +142,6 @@ body.fullscreen-center {
 .settings-table input[type="number"],
 .settings-table input[type="password"],
 .settings-table select { width:100%; }
+.server-status { margin-top:16px; }
+.server-status.connected { color:#2e7d32; }
+.server-status.disconnected { color:#b00020; }


### PR DESCRIPTION
## Summary
- maintain persistent TCP and UDP sockets initialized at LAN startup
- expose connection status via new `/api/stream_status` HTTP endpoint
- show server connection indicator on main page when TCP/UDP streaming enabled

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install espressif-idf` *(fails: no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68930a7439088329887b88faca070feb