### PR TITLE
feat: show server status when UDP/TCP configured

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -44,7 +44,12 @@ function updateServerStatus() {
       el.textContent = `TCP: ${s.tcp ? 'подключен' : 'нет'}, UDP: ${s.udp ? 'подключен' : 'нет'}`;
       el.className = 'server-status ' + (connected ? 'connected' : 'disconnected');
     })
-    .catch(_ => {});
+    .catch(_ => {
+      const el = document.getElementById('server_status');
+      if (!el) return;
+      el.textContent = 'TCP: нет, UDP: нет';
+      el.className = 'server-status disconnected';
+    });
 }
 
 function loadSidebar() {
@@ -158,6 +163,8 @@ document.addEventListener("DOMContentLoaded", () => {
         const st = document.getElementById('server_status');
         if (st) {
           st.style.display = 'block';
+          st.textContent = 'TCP: нет, UDP: нет';
+          st.className = 'server-status disconnected';
           updateServerStatus();
           statusInterval = setInterval(updateServerStatus, 5000);
         }


### PR DESCRIPTION
## Summary
- show server connection indicator when UDP or TCP checkbox is enabled
- display disconnected status when connection is absent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68930f449aa88329ac86a625697ec951