### PR TITLE
feat: add password management and secure logout

### DIFF
--- a/firmware/components/um1_auth/include/um1_auth.h
+++ b/firmware/components/um1_auth/include/um1_auth.h
@@ -22,10 +22,13 @@ typedef struct {
     bool cookie_secure;            // Secure flag (HTTPS only)
 } token_auth_config_t;
 
+extern token_auth_config_t auth_config;
+
 void token_auth_init(void);
 bool is_public_uri(const char *uri);
 esp_err_t handle_login(httpd_req_t *req);
 esp_err_t handle_logout(httpd_req_t *req);
+esp_err_t handle_change_password(httpd_req_t *req);
 esp_err_t token_auth_register_endpoints(httpd_handle_t server);
 bool token_auth_check(httpd_req_t *req);
 void token_auth_set_no_store(httpd_req_t *req);

--- a/firmware/components/um1_auth/um1_auth.c
+++ b/firmware/components/um1_auth/um1_auth.c
@@ -1,4 +1,5 @@
 #include "um1_auth.h"
+#include "cJSON.h"
 
 static const char *TAG = "token_auth";
 
@@ -135,6 +136,50 @@ esp_err_t handle_logout(httpd_req_t *req){
     httpd_resp_set_hdr(req, "Set-Cookie", "UM1SESS=; Path=/; Max-Age=0; HttpOnly; SameSite=Strict");
     httpd_resp_sendstr(req, "bye");
     return ESP_OK;
+}
+
+esp_err_t handle_change_password(httpd_req_t *req){
+    token_auth_set_no_store(req);
+    if(!token_is_valid(req)){
+        httpd_resp_set_status(req, "401 Unauthorized");
+        return httpd_resp_sendstr(req, "unauthorized");
+    }
+    char body[256];
+    if(!read_body(req, body, sizeof(body))){
+        httpd_resp_set_status(req, "400 Bad Request");
+        return httpd_resp_sendstr(req, "no body");
+    }
+    char oldp[160]={0}, newp[160]={0};
+    parse_field(body, "old_password", oldp, sizeof(oldp));
+    parse_field(body, "new_password", newp, sizeof(newp));
+    if(strcmp(oldp, TA.pass)!=0){
+        httpd_resp_set_status(req, "403 Forbidden");
+        return httpd_resp_sendstr(req, "wrong password");
+    }
+    strlcpy(TA.pass, newp, sizeof(TA.pass));
+    auth_config.password = strdup(newp);
+
+    FILE *f = fopen("/spiffs/src/config.json", "r");
+    cJSON *root = NULL;
+    if(f){
+        fseek(f,0,SEEK_END); long len=ftell(f); rewind(f);
+        char *buf = malloc(len+1);
+        if(buf){ fread(buf,1,len,f); buf[len]=0; root = cJSON_Parse(buf); free(buf); }
+        fclose(f);
+    }
+    if(!root) root = cJSON_CreateObject();
+    cJSON *auth = cJSON_GetObjectItem(root, "auth");
+    if(!auth){ auth = cJSON_CreateObject(); cJSON_AddItemToObject(root, "auth", auth); }
+    cJSON_ReplaceItemInObject(auth, "username", cJSON_CreateString(TA.user));
+    cJSON_ReplaceItemInObject(auth, "password", cJSON_CreateString(TA.pass));
+    char *out = cJSON_Print(root);
+    f = fopen("/spiffs/src/config.json", "w");
+    if(f){ fwrite(out,1,strlen(out),f); fclose(f); }
+    free(out);
+    cJSON_Delete(root);
+
+    httpd_resp_set_type(req, "application/json");
+    return httpd_resp_sendstr(req, "{\"ok\":true}");
 }
 
 void token_auth_init(void) {

--- a/firmware/components/um1_config/um1_config.c
+++ b/firmware/components/um1_config/um1_config.c
@@ -1,4 +1,5 @@
 #include "include/um1_config.h"
+#include "um1_auth.h"
 
 lan_config_t global_lan_config;
 wifi_config_ap_t global_wifi_config;
@@ -30,6 +31,16 @@ void read_config_and_apply(void)
         ESP_LOGE("CONFIG", "JSON parse error");
         free(data);
         return;
+    }
+
+    cJSON *auth = cJSON_GetObjectItem(root, "auth");
+    if (auth) {
+        cJSON *u = cJSON_GetObjectItem(auth, "username");
+        cJSON *p = cJSON_GetObjectItem(auth, "password");
+        if (u && p) {
+            auth_config.username = strdup(u->valuestring);
+            auth_config.password = strdup(p->valuestring);
+        }
     }
 
     cJSON *lan = cJSON_GetObjectItem(root, "lan");

--- a/firmware/components/um1_http_server/um1_http_server.c
+++ b/firmware/components/um1_http_server/um1_http_server.c
@@ -24,6 +24,13 @@ httpd_uri_t logout = {
     .user_ctx = NULL
 };
 
+httpd_uri_t change_password = {
+    .uri      = "/api/change_password",
+    .method   = HTTP_POST,
+    .handler  = handle_change_password,
+    .user_ctx = NULL
+};
+
 httpd_uri_t system_info = {
     .uri       = "/api/system_info",
     .method    = HTTP_GET,
@@ -639,6 +646,7 @@ httpd_handle_t start_webserver(void)
         httpd_register_uri_handler(server, &ws);
         httpd_register_uri_handler(server, &login);
         httpd_register_uri_handler(server, &logout);
+        httpd_register_uri_handler(server, &change_password);
         httpd_register_uri_handler(server, &system_info);
         httpd_register_uri_handler(server, &config_get_uri);
         httpd_register_uri_handler(server, &config_save);

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -27,7 +27,7 @@
         e.preventDefault();
         try {
           localStorage.removeItem('um1_auth');
-          await fetch('/logout', { method: 'GET', credentials: 'include' });
+          await fetch('/logout', { method: 'POST', credentials: 'include' });
         } catch(_){}
         location.href = '/login.html';
       });

--- a/web/src/config.json
+++ b/web/src/config.json
@@ -1,9 +1,13 @@
 {
-	"uart1": {
-	  "baudrate": 115200,
-	  "parity": "none",
-	  "stop_bits": 1
-		},
+        "auth": {
+          "username": "admin",
+          "password": "admin"
+        },
+        "uart1": {
+          "baudrate": 115200,
+          "parity": "none",
+          "stop_bits": 1
+                },
 	"uart2": {
 	  "baudrate": 9600,
 	  "parity": "even",

--- a/web/src/settings/settings.html
+++ b/web/src/settings/settings.html
@@ -64,6 +64,22 @@
         <tr><td>Sync Interval (sec):</td><td><input type="number" id="sntp_interval" /></td></tr>
       </table>
     </div>
+    <div class="card">
+      <h3>Смена пароля</h3>
+      <div class="fld">
+        <label>Текущий пароль</label>
+        <input type="password" id="old_password" />
+      </div>
+      <div class="fld">
+        <label>Новый пароль</label>
+        <input type="password" id="new_password" />
+      </div>
+      <div class="fld">
+        <label>Подтвердите пароль</label>
+        <input type="password" id="confirm_password" />
+      </div>
+      <button id="change_pass_btn">Сменить пароль</button>
+    </div>
     <button onclick="collectSettings()">Сохранить настройки</button>
     <pre id="json_output"></pre>
   </div>

--- a/web/src/settings/settings.js
+++ b/web/src/settings/settings.js
@@ -64,4 +64,30 @@ document.addEventListener('DOMContentLoaded',()=>{
   });
   toggleAllFields();
   loadConfigFromServer();
+
+  const btn = document.getElementById('change_pass_btn');
+  if(btn){
+    btn.addEventListener('click', async () => {
+      const oldp = document.getElementById('old_password').value.trim();
+      const newp = document.getElementById('new_password').value.trim();
+      const conf = document.getElementById('confirm_password').value.trim();
+      if(!newp || newp !== conf){
+        showNotification('❌ Пароли не совпадают', true);
+        return;
+      }
+      const body = new URLSearchParams({ old_password: oldp, new_password: newp });
+      try{
+        const r = await fetch('/api/change_password', {
+          method:'POST',
+          headers:{'Content-Type':'application/x-www-form-urlencoded'},
+          body: body.toString(),
+          credentials:'include'
+        });
+        if(r.ok) showNotification('✅ Пароль изменён');
+        else showNotification('❌ Не удалось изменить пароль', true);
+      }catch(_){
+        showNotification('❌ Ошибка соединения', true);
+      }
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- secure logout by using POST request
- add UI and backend endpoint for password change and persist credentials
- load auth credentials from config at startup

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689331f9b0a4832993eeea3cc9cf75c3