### PR TITLE
Enable Enter key login and allow updating username

### DIFF
--- a/firmware/components/um1_auth/um1_auth.c
+++ b/firmware/components/um1_auth/um1_auth.c
@@ -149,15 +149,22 @@ esp_err_t handle_change_password(httpd_req_t *req){
         httpd_resp_set_status(req, "400 Bad Request");
         return httpd_resp_sendstr(req, "no body");
     }
-    char oldp[160]={0}, newp[160]={0};
+    char oldp[160]={0}, newp[160]={0}, newu[96]={0};
     parse_field(body, "old_password", oldp, sizeof(oldp));
     parse_field(body, "new_password", newp, sizeof(newp));
+    parse_field(body, "new_username", newu, sizeof(newu));
     if(strcmp(oldp, TA.pass)!=0){
         httpd_resp_set_status(req, "403 Forbidden");
         return httpd_resp_sendstr(req, "wrong password");
     }
-    strlcpy(TA.pass, newp, sizeof(TA.pass));
-    auth_config.password = strdup(newp);
+    if(newp[0]){
+        strlcpy(TA.pass, newp, sizeof(TA.pass));
+        auth_config.password = strdup(newp);
+    }
+    if(newu[0]){
+        strlcpy(TA.user, newu, sizeof(TA.user));
+        auth_config.username = strdup(newu);
+    }
 
     FILE *f = fopen("/spiffs/src/config.json", "r");
     cJSON *root = NULL;

--- a/web/src/login.js
+++ b/web/src/login.js
@@ -1,5 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('login_btn').addEventListener('click', async () => {
+  const btn = document.getElementById('login_btn');
+
+  const doLogin = async () => {
     const u = document.getElementById('login_user').value.trim();
     const p = document.getElementById('login_pass').value.trim();
 
@@ -22,5 +24,16 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch (e) {
       notify('⚠️ Ошибка соединения', 'error');
     }
+  };
+
+  btn.addEventListener('click', doLogin);
+  ['login_user', 'login_pass'].forEach(id => {
+    const el = document.getElementById(id);
+    el.addEventListener('keydown', e => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        doLogin();
+      }
+    });
   });
 });

--- a/web/src/settings/settings.html
+++ b/web/src/settings/settings.html
@@ -65,7 +65,11 @@
       </table>
     </div>
     <div class="card">
-      <h3>Смена пароля</h3>
+      <h3>Логин и пароль</h3>
+      <div class="fld">
+        <label>Новый логин</label>
+        <input type="text" id="new_username" />
+      </div>
       <div class="fld">
         <label>Текущий пароль</label>
         <input type="password" id="old_password" />
@@ -78,7 +82,7 @@
         <label>Подтвердите пароль</label>
         <input type="password" id="confirm_password" />
       </div>
-      <button id="change_pass_btn">Сменить пароль</button>
+      <button id="change_creds_btn">Изменить</button>
     </div>
     <button onclick="collectSettings()">Сохранить настройки</button>
     <pre id="json_output"></pre>

--- a/web/src/settings/settings.js
+++ b/web/src/settings/settings.js
@@ -65,17 +65,27 @@ document.addEventListener('DOMContentLoaded',()=>{
   toggleAllFields();
   loadConfigFromServer();
 
-  const btn = document.getElementById('change_pass_btn');
+  const btn = document.getElementById('change_creds_btn');
   if(btn){
     btn.addEventListener('click', async () => {
+      const newu = document.getElementById('new_username').value.trim();
       const oldp = document.getElementById('old_password').value.trim();
       const newp = document.getElementById('new_password').value.trim();
       const conf = document.getElementById('confirm_password').value.trim();
-      if(!newp || newp !== conf){
+
+      if(!newu && !newp){
+        showNotification('❌ Нет новых данных', true);
+        return;
+      }
+      if(newp && newp !== conf){
         showNotification('❌ Пароли не совпадают', true);
         return;
       }
-      const body = new URLSearchParams({ old_password: oldp, new_password: newp });
+
+      const body = new URLSearchParams({ old_password: oldp });
+      if(newu) body.append('new_username', newu);
+      if(newp) body.append('new_password', newp);
+
       try{
         const r = await fetch('/api/change_password', {
           method:'POST',
@@ -83,8 +93,8 @@ document.addEventListener('DOMContentLoaded',()=>{
           body: body.toString(),
           credentials:'include'
         });
-        if(r.ok) showNotification('✅ Пароль изменён');
-        else showNotification('❌ Не удалось изменить пароль', true);
+        if(r.ok) showNotification('✅ Данные обновлены');
+        else showNotification('❌ Не удалось обновить данные', true);
       }catch(_){
         showNotification('❌ Ошибка соединения', true);
       }


### PR DESCRIPTION
## Summary
- allow login form submit via Enter key
- add UI and backend support for updating username along with password

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68933843745483299fe9d8c205c0019e