### PR TITLE
Ensure notification visible after saving settings

### DIFF
--- a/web/src/app.js
+++ b/web/src/app.js
@@ -18,6 +18,7 @@
     box.textContent = msg;
     box.className = 'notification' + (type ? ' ' + type : '');
     box.style.display = 'block';
+    box.scrollIntoView({behavior:'smooth', block:'center'});
     setTimeout(() => box.style.display = 'none', 4000);
   };
   document.addEventListener('DOMContentLoaded', () => {

--- a/web/src/network/network.js
+++ b/web/src/network/network.js
@@ -17,6 +17,7 @@ function showNotification(message, isError=false){
   notif.textContent = message;
   notif.className = 'notification' + (isError ? ' error' : ' success');
   notif.style.display = 'block';
+  notif.scrollIntoView({behavior:'smooth', block:'center'});
   setTimeout(()=>notif.style.display='none',3000);
 }
 function collectSettings(){

--- a/web/src/settings/settings.js
+++ b/web/src/settings/settings.js
@@ -3,6 +3,7 @@ function showNotification(message, isError=false){
   notif.textContent = message;
   notif.className = 'notification' + (isError ? ' error' : ' success');
   notif.style.display = 'block';
+  notif.scrollIntoView({behavior:'smooth', block:'center'});
   setTimeout(()=>notif.style.display='none',3000);
 }
 function toggleAllFields(){


### PR DESCRIPTION
## Summary
- Scroll notifications into view so they stay visible after saving settings
- Apply same behavior to global notify helper for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689340e9bd788329872a9cc293f7ee02