### PR TITLE
feat: add connection status indicators

### DIFF
--- a/web/src/index.html
+++ b/web/src/index.html
@@ -35,7 +35,10 @@
         <label><input type="checkbox" id="uart1" /> uart1</label>
         <label><input type="checkbox" id="uart2" /> uart2</label>
       </div>
-      <div id="server_status" class="server-status" style="display:none;"></div>
+      <div id="server_status" class="server-status" style="display:none;">
+        TCP <span id="tcp_status" class="status-dot"></span>
+        UDP <span id="udp_status" class="status-dot"></span>
+      </div>
     </div>
     <div id="log" class="stream-output"></div>
   </div>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -38,17 +38,16 @@ function updateServerStatus() {
   fetch('/api/stream_status')
     .then(r => r.json())
     .then(s => {
-      const el = document.getElementById('server_status');
-      if (!el) return;
-      const connected = s.tcp || s.udp;
-      el.textContent = `TCP: ${s.tcp ? 'подключен' : 'нет'}, UDP: ${s.udp ? 'подключен' : 'нет'}`;
-      el.className = 'server-status ' + (connected ? 'connected' : 'disconnected');
+      const tcp = document.getElementById('tcp_status');
+      const udp = document.getElementById('udp_status');
+      if (tcp) tcp.classList.toggle('on', s.tcp);
+      if (udp) udp.classList.toggle('on', s.udp);
     })
     .catch(_ => {
-      const el = document.getElementById('server_status');
-      if (!el) return;
-      el.textContent = 'TCP: нет, UDP: нет';
-      el.className = 'server-status disconnected';
+      const tcp = document.getElementById('tcp_status');
+      const udp = document.getElementById('udp_status');
+      if (tcp) tcp.classList.remove('on');
+      if (udp) udp.classList.remove('on');
     });
 }
 
@@ -163,8 +162,10 @@ document.addEventListener("DOMContentLoaded", () => {
         const st = document.getElementById('server_status');
         if (st) {
           st.style.display = 'block';
-          st.textContent = 'TCP: нет, UDP: нет';
-          st.className = 'server-status disconnected';
+          const tcp = document.getElementById('tcp_status');
+          const udp = document.getElementById('udp_status');
+          if (tcp) tcp.classList.remove('on');
+          if (udp) udp.classList.remove('on');
           updateServerStatus();
           statusInterval = setInterval(updateServerStatus, 5000);
         }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -143,5 +143,14 @@ body.fullscreen-center {
 .settings-table input[type="password"],
 .settings-table select { width:100%; }
 .server-status { margin-top:16px; }
-.server-status.connected { color:#2e7d32; }
-.server-status.disconnected { color:#b00020; }
+
+.status-dot {
+  display:inline-block;
+  width:10px;
+  height:10px;
+  margin-left:4px;
+  border-radius:50%;
+  background:#b00020;
+}
+
+.status-dot.on { background:#2e7d32; }


### PR DESCRIPTION
## Summary
- replace text server status with TCP/UDP circles
- toggle indicator colors based on connection status
- add CSS for status dots

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894465ec86c8329b2da890db825a7a5