### PR TITLE
feat: support concurrent AP and STA wifi

### DIFF
--- a/firmware/components/um1_config/include/um1_config.h
+++ b/firmware/components/um1_config/include/um1_config.h
@@ -14,12 +14,21 @@ typedef struct {
 } lan_config_t;
 
 typedef struct {
-    bool enabled;
     char ssid[32];
     char password[64];
     char authmode[16];
+    bool dhcp;
+    char static_ip[16];
+    char subnet[16];
+    char gateway[16];
+} wifi_if_config_t;
+
+typedef struct {
+    bool enabled;
     char mode[8];
-} wifi_config_ap_t;
+    wifi_if_config_t ap;
+    wifi_if_config_t sta;
+} wifi_config_t;
 
 typedef struct {
     int baudrate;
@@ -47,7 +56,7 @@ typedef struct {
 } sntp_config_t;
 
 extern lan_config_t global_lan_config;
-extern wifi_config_ap_t global_wifi_config;
+extern wifi_config_t global_wifi_config;
 extern um1_uart_config_t global_uart_config[2];
 extern mqtt_config_t global_mqtt_config;
 extern stream_config_t global_tcp_config;

--- a/firmware/components/um1_config/um1_config.c
+++ b/firmware/components/um1_config/um1_config.c
@@ -2,7 +2,7 @@
 #include "um1_auth.h"
 
 lan_config_t global_lan_config;
-wifi_config_ap_t global_wifi_config;
+wifi_config_t global_wifi_config;
 um1_uart_config_t global_uart_config[2];
 mqtt_config_t global_mqtt_config;
 stream_config_t global_tcp_config;
@@ -60,16 +60,32 @@ void read_config_and_apply(void)
     cJSON *wifi = cJSON_GetObjectItem(root, "wifi");
     if (wifi) {
         global_wifi_config.enabled = cJSON_GetObjectItem(wifi, "enabled")->valueint;
-        strcpy(global_wifi_config.ssid, cJSON_GetObjectItem(wifi, "ssid")->valuestring);
-        strcpy(global_wifi_config.password, cJSON_GetObjectItem(wifi, "password")->valuestring);
-        strcpy(global_wifi_config.authmode, cJSON_GetObjectItem(wifi, "authmode")->valuestring);
         strcpy(global_wifi_config.mode, cJSON_GetObjectItem(wifi, "mode")->valuestring);
 
-        ESP_LOGI("CONFIG", "WiFi config: enabled=%d, ssid=%s, password=%s, authmode=%s, mode=%s",
+        cJSON *ap = cJSON_GetObjectItem(wifi, "ap");
+        if (ap) {
+            strcpy(global_wifi_config.ap.ssid, cJSON_GetObjectItem(ap, "ssid")->valuestring);
+            strcpy(global_wifi_config.ap.password, cJSON_GetObjectItem(ap, "password")->valuestring);
+            strcpy(global_wifi_config.ap.authmode, cJSON_GetObjectItem(ap, "authmode")->valuestring);
+            global_wifi_config.ap.dhcp = cJSON_GetObjectItem(ap, "dhcp")->valueint;
+            strcpy(global_wifi_config.ap.static_ip, cJSON_GetObjectItem(ap, "static_ip")->valuestring);
+            strcpy(global_wifi_config.ap.subnet, cJSON_GetObjectItem(ap, "subnet")->valuestring);
+            strcpy(global_wifi_config.ap.gateway, cJSON_GetObjectItem(ap, "gateway")->valuestring);
+        }
+
+        cJSON *sta = cJSON_GetObjectItem(wifi, "sta");
+        if (sta) {
+            strcpy(global_wifi_config.sta.ssid, cJSON_GetObjectItem(sta, "ssid")->valuestring);
+            strcpy(global_wifi_config.sta.password, cJSON_GetObjectItem(sta, "password")->valuestring);
+            strcpy(global_wifi_config.sta.authmode, cJSON_GetObjectItem(sta, "authmode")->valuestring);
+            global_wifi_config.sta.dhcp = cJSON_GetObjectItem(sta, "dhcp")->valueint;
+            strcpy(global_wifi_config.sta.static_ip, cJSON_GetObjectItem(sta, "static_ip")->valuestring);
+            strcpy(global_wifi_config.sta.subnet, cJSON_GetObjectItem(sta, "subnet")->valuestring);
+            strcpy(global_wifi_config.sta.gateway, cJSON_GetObjectItem(sta, "gateway")->valuestring);
+        }
+
+        ESP_LOGI("CONFIG", "WiFi config: enabled=%d, mode=%s",
                  global_wifi_config.enabled,
-                 global_wifi_config.ssid,
-                 global_wifi_config.password,
-				 global_wifi_config.authmode,
                  global_wifi_config.mode);
     }
 

--- a/firmware/components/um1_wifi/um1_wifi.c
+++ b/firmware/components/um1_wifi/um1_wifi.c
@@ -4,13 +4,14 @@
 #define TCP_PORT 4444
 #define LISTEN_BACKLOG 5
 
-static esp_netif_t *wifi_netif = NULL;
+static esp_netif_t *wifi_ap_netif = NULL;
+static esp_netif_t *wifi_sta_netif = NULL;
 
 /* ===== AP MODE ONLY: TCP Server ===== */
 static void wifi_tcp_server_task(void *pvParameters)
 {
     esp_netif_ip_info_t ip_info;
-    ESP_ERROR_CHECK(esp_netif_get_ip_info(wifi_netif, &ip_info));
+    ESP_ERROR_CHECK(esp_netif_get_ip_info(wifi_ap_netif, &ip_info));
 
     int listen_sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     if (listen_sock < 0) {
@@ -117,52 +118,65 @@ void start_wifi(void)
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
 
-    wifi_auth_mode_t auth_mode = get_auth_mode(global_wifi_config.authmode);
+    bool do_ap = strcmp(global_wifi_config.mode, "ap") == 0 || strcmp(global_wifi_config.mode, "apsta") == 0;
+    bool do_sta = strcmp(global_wifi_config.mode, "sta") == 0 || strcmp(global_wifi_config.mode, "apsta") == 0;
 
-    if (strcmp(global_wifi_config.mode, "sta") == 0) {
-        esp_netif_t *ap_netif = esp_netif_get_handle_from_ifkey("WIFI_AP_DEF");
-        if (ap_netif) {
-            esp_netif_dhcps_stop(ap_netif);
-            esp_netif_destroy(ap_netif);
-            ESP_LOGI(TAG, "AP interface removed to ensure clean STA start");
+    wifi_mode_t mode = WIFI_MODE_NULL;
+    if (do_ap && do_sta) mode = WIFI_MODE_APSTA;
+    else if (do_ap) mode = WIFI_MODE_AP;
+    else mode = WIFI_MODE_STA;
+
+    if (do_ap) {
+        wifi_ap_netif = esp_netif_create_default_wifi_ap();
+        if (!global_wifi_config.ap.dhcp) {
+            esp_netif_dhcps_stop(wifi_ap_netif);
+            esp_netif_ip_info_t ip_info = {0};
+            ip_info.ip.addr = inet_addr(global_wifi_config.ap.static_ip);
+            ip_info.netmask.addr = inet_addr(global_wifi_config.ap.subnet);
+            ip_info.gw.addr = inet_addr(global_wifi_config.ap.gateway);
+            ESP_ERROR_CHECK(esp_netif_set_ip_info(wifi_ap_netif, &ip_info));
         }
+        ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler_ap, NULL, NULL));
 
-        wifi_netif = esp_netif_create_default_wifi_sta();
+        wifi_config_t ap_cfg = {0};
+        strncpy((char *)ap_cfg.ap.ssid, global_wifi_config.ap.ssid, sizeof(ap_cfg.ap.ssid));
+        ap_cfg.ap.ssid_len = strlen(global_wifi_config.ap.ssid);
+        strncpy((char *)ap_cfg.ap.password, global_wifi_config.ap.password, sizeof(ap_cfg.ap.password));
+        ap_cfg.ap.channel = 1;
+        ap_cfg.ap.max_connection = 4;
+        wifi_auth_mode_t ap_auth = get_auth_mode(global_wifi_config.ap.authmode);
+        ap_cfg.ap.authmode = strlen(global_wifi_config.ap.password) == 0 ? WIFI_AUTH_OPEN : ap_auth;
+        ap_cfg.ap.pmf_cfg.required = true;
+        ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &ap_cfg));
+    }
 
+    if (do_sta) {
+        wifi_sta_netif = esp_netif_create_default_wifi_sta();
+        if (!global_wifi_config.sta.dhcp) {
+            esp_netif_dhcpc_stop(wifi_sta_netif);
+            esp_netif_ip_info_t ip_info = {0};
+            ip_info.ip.addr = inet_addr(global_wifi_config.sta.static_ip);
+            ip_info.netmask.addr = inet_addr(global_wifi_config.sta.subnet);
+            ip_info.gw.addr = inet_addr(global_wifi_config.sta.gateway);
+            ESP_ERROR_CHECK(esp_netif_set_ip_info(wifi_sta_netif, &ip_info));
+        }
         ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler_sta, NULL, NULL));
         ESP_ERROR_CHECK(esp_event_handler_instance_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &wifi_event_handler_sta, NULL, NULL));
 
-        wifi_config_t wifi_config = { 0 };
-        strncpy((char *)wifi_config.sta.ssid, global_wifi_config.ssid, sizeof(wifi_config.sta.ssid));
-        strncpy((char *)wifi_config.sta.password, global_wifi_config.password, sizeof(wifi_config.sta.password));
-        wifi_config.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
-        wifi_config.sta.threshold.authmode = auth_mode;
-        wifi_config.sta.sae_pwe_h2e = WPA3_SAE_PWE_BOTH;
-
-        ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
-        ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
-        ESP_ERROR_CHECK(esp_wifi_start());
-        ESP_ERROR_CHECK(esp_wifi_connect());
-
-        ESP_LOGI(TAG, "Started in STA mode. SSID: %s, Authmode: %d", global_wifi_config.ssid, auth_mode);
-    } else {
-        wifi_netif = esp_netif_create_default_wifi_ap();
-
-        ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler_ap, NULL, NULL));
-
-        wifi_config_t wifi_config = { 0 };
-        strncpy((char *)wifi_config.ap.ssid, global_wifi_config.ssid, sizeof(wifi_config.ap.ssid));
-        wifi_config.ap.ssid_len = strlen(global_wifi_config.ssid);
-        strncpy((char *)wifi_config.ap.password, global_wifi_config.password, sizeof(wifi_config.ap.password));
-        wifi_config.ap.channel = 1;
-        wifi_config.ap.max_connection = 4;
-        wifi_config.ap.authmode = strlen(global_wifi_config.password) == 0 ? WIFI_AUTH_OPEN : auth_mode;
-        wifi_config.ap.pmf_cfg.required = true;
-
-        ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_AP));
-        ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &wifi_config));
-        ESP_ERROR_CHECK(esp_wifi_start());
-
-        ESP_LOGI(TAG, "Started in AP mode. SSID: %s, Authmode: %d", global_wifi_config.ssid, wifi_config.ap.authmode);
+        wifi_config_t sta_cfg = {0};
+        strncpy((char *)sta_cfg.sta.ssid, global_wifi_config.sta.ssid, sizeof(sta_cfg.sta.ssid));
+        strncpy((char *)sta_cfg.sta.password, global_wifi_config.sta.password, sizeof(sta_cfg.sta.password));
+        sta_cfg.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
+        sta_cfg.sta.threshold.authmode = get_auth_mode(global_wifi_config.sta.authmode);
+        sta_cfg.sta.sae_pwe_h2e = WPA3_SAE_PWE_BOTH;
+        ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &sta_cfg));
     }
+
+    ESP_ERROR_CHECK(esp_wifi_set_mode(mode));
+    ESP_ERROR_CHECK(esp_wifi_start());
+    if (do_sta) {
+        ESP_ERROR_CHECK(esp_wifi_connect());
+    }
+
+    ESP_LOGI(TAG, "Started WiFi mode=%s", global_wifi_config.mode);
 }

--- a/web/src/config.json
+++ b/web/src/config.json
@@ -1,38 +1,53 @@
 {
-        "auth": {
-          "username": "admin",
-          "password": "admin"
-        },
-        "uart1": {
-          "baudrate": 115200,
-          "parity": "none",
-          "stop_bits": 1
-                },
-	"uart2": {
-	  "baudrate": 9600,
-	  "parity": "even",
-	  "stop_bits": 1
-	},
-	"lan":	{
-		"dhcp":	true,
-		"static_ip":	"192.168.0.100",
-		"subnet":	"255.255.255.0",
-		"gateway":	"192.168.0.1"
-	},
-	"wifi":	{
-		"enabled":	true,
-		"mode": "ap",
-		"ssid":	"MyNetwork",
-		"password":	"MyPassword",
-		"authmode": "wpa2"
-	},
-	"mqtt": {
-		"enabled": true,
-		"broker": "mqtt://uhcloud.ru",
-		"username": "igtrefilov",
-		"password": "estrella",
-		"tx_enabled": true
-	},
+  "auth": {
+    "username": "admin",
+    "password": "admin"
+  },
+  "uart1": {
+    "baudrate": 115200,
+    "parity": "none",
+    "stop_bits": 1
+  },
+  "uart2": {
+    "baudrate": 9600,
+    "parity": "even",
+    "stop_bits": 1
+  },
+  "lan": {
+    "dhcp": true,
+    "static_ip": "192.168.0.100",
+    "subnet": "255.255.255.0",
+    "gateway": "192.168.0.1"
+  },
+  "wifi": {
+    "enabled": true,
+    "mode": "apsta",
+    "ap": {
+      "ssid": "MyAP",
+      "password": "ap_pass",
+      "authmode": "wpa2",
+      "dhcp": true,
+      "static_ip": "192.168.4.1",
+      "subnet": "255.255.255.0",
+      "gateway": "192.168.4.1"
+    },
+    "sta": {
+      "ssid": "MyNetwork",
+      "password": "MyPassword",
+      "authmode": "wpa2",
+      "dhcp": true,
+      "static_ip": "192.168.0.50",
+      "subnet": "255.255.255.0",
+      "gateway": "192.168.0.1"
+    }
+  },
+  "mqtt": {
+    "enabled": true,
+    "broker": "mqtt://uhcloud.ru",
+    "username": "igtrefilov",
+    "password": "estrella",
+    "tx_enabled": true
+  },
   "tcp": {
     "enabled": true,
     "server": "192.168.1.100",
@@ -43,9 +58,9 @@
     "server": "",
     "port": 0
   },
-	"sntp": {
-	  "enabled": true,
-	  "server_ip": "pool.ntp.org",
-	  "sync_interval_sec": 3600
-	}
+  "sntp": {
+    "enabled": true,
+    "server_ip": "pool.ntp.org",
+    "sync_interval_sec": 3600
+  }
 }

--- a/web/src/network/network.html
+++ b/web/src/network/network.html
@@ -33,11 +33,32 @@
       <h3>Wi‑Fi</h3>
       <table class="settings-table">
         <tr><td>Включено:</td><td><input type="checkbox" id="wifi_enabled" /></td></tr>
-        <tr><td>SSID:</td><td><input type="text" id="wifi_ssid" /></td></tr>
-        <tr><td>Password:</td><td><input type="password" id="wifi_password" /></td></tr>
-        <tr><td>Режим:</td><td><select id="wifi_mode"><option value="ap">AP</option><option value="sta">STA</option></select></td></tr>
-        <tr><td>Auth Mode:</td><td><select id="wifi_authmode"><option value="open">Open</option><option value="wpa2">WPA2-PSK</option><option value="wpa3">WPA3-SAE</option><option value="wpa_wpa2">WPA/WPA2 Mixed</option></select></td></tr>
+        <tr><td>Режим:</td><td><select id="wifi_mode"><option value="ap">AP</option><option value="sta">STA</option><option value="apsta">AP+STA</option></select></td></tr>
       </table>
+      <div id="wifi_ap_section">
+        <h4>AP</h4>
+        <table class="settings-table">
+          <tr><td>SSID:</td><td><input type="text" id="wifi_ap_ssid" /></td></tr>
+          <tr><td>Password:</td><td><input type="password" id="wifi_ap_password" /></td></tr>
+          <tr><td>Auth Mode:</td><td><select id="wifi_ap_authmode"><option value="open">Open</option><option value="wpa2">WPA2-PSK</option><option value="wpa3">WPA3-SAE</option><option value="wpa_wpa2">WPA/WPA2 Mixed</option></select></td></tr>
+          <tr><td>DHCP:</td><td><input type="checkbox" id="wifi_ap_dhcp" /></td></tr>
+          <tr><td>Static IP:</td><td><input type="text" id="wifi_ap_static_ip" /></td></tr>
+          <tr><td>Subnet:</td><td><input type="text" id="wifi_ap_subnet" /></td></tr>
+          <tr><td>Gateway:</td><td><input type="text" id="wifi_ap_gateway" /></td></tr>
+        </table>
+      </div>
+      <div id="wifi_sta_section">
+        <h4>STA</h4>
+        <table class="settings-table">
+          <tr><td>SSID:</td><td><input type="text" id="wifi_sta_ssid" /></td></tr>
+          <tr><td>Password:</td><td><input type="password" id="wifi_sta_password" /></td></tr>
+          <tr><td>Auth Mode:</td><td><select id="wifi_sta_authmode"><option value="open">Open</option><option value="wpa2">WPA2-PSK</option><option value="wpa3">WPA3-SAE</option><option value="wpa_wpa2">WPA/WPA2 Mixed</option></select></td></tr>
+          <tr><td>DHCP:</td><td><input type="checkbox" id="wifi_sta_dhcp" /></td></tr>
+          <tr><td>Static IP:</td><td><input type="text" id="wifi_sta_static_ip" /></td></tr>
+          <tr><td>Subnet:</td><td><input type="text" id="wifi_sta_subnet" /></td></tr>
+          <tr><td>Gateway:</td><td><input type="text" id="wifi_sta_gateway" /></td></tr>
+        </table>
+      </div>
     </div>
     <button onclick="collectSettings()">Сохранить настройки</button>
     <pre id="json_output"></pre>

--- a/web/src/network/network.js
+++ b/web/src/network/network.js
@@ -7,9 +7,25 @@ function toggleLanFields() {
 }
 function toggleWifiFields() {
   const wifiEnabled = document.getElementById('wifi_enabled').checked;
-  ['wifi_ssid','wifi_password','wifi_mode','wifi_authmode'].forEach(id => {
-    const el = document.getElementById(id);
-    el.disabled = !wifiEnabled;
+  ['wifi_mode'].forEach(id => {
+    document.getElementById(id).disabled = !wifiEnabled;
+  });
+  ['wifi_ap_section','wifi_sta_section'].forEach(id => {
+    const section = document.getElementById(id);
+    section.querySelectorAll('input, select').forEach(el => el.disabled = !wifiEnabled);
+  });
+}
+
+function toggleWifiModeFields() {
+  const mode = document.getElementById('wifi_mode').value;
+  document.getElementById('wifi_ap_section').style.display = (mode === 'ap' || mode === 'apsta') ? 'block' : 'none';
+  document.getElementById('wifi_sta_section').style.display = (mode === 'sta' || mode === 'apsta') ? 'block' : 'none';
+}
+
+function toggleDhcp(prefix) {
+  const dhcp = document.getElementById(prefix + '_dhcp').checked;
+  ['static_ip','subnet','gateway'].forEach(f => {
+    document.getElementById(prefix + '_' + f).disabled = dhcp;
   });
 }
 function showNotification(message, isError=false){
@@ -30,10 +46,25 @@ function collectSettings(){
     },
     wifi:{
       enabled: document.getElementById('wifi_enabled').checked,
-      ssid: document.getElementById('wifi_ssid').value,
-      password: document.getElementById('wifi_password').value,
-      authmode: document.getElementById('wifi_authmode').value,
-      mode: document.getElementById('wifi_mode').value
+      mode: document.getElementById('wifi_mode').value,
+      ap:{
+        ssid: document.getElementById('wifi_ap_ssid').value,
+        password: document.getElementById('wifi_ap_password').value,
+        authmode: document.getElementById('wifi_ap_authmode').value,
+        dhcp: document.getElementById('wifi_ap_dhcp').checked,
+        static_ip: document.getElementById('wifi_ap_static_ip').value,
+        subnet: document.getElementById('wifi_ap_subnet').value,
+        gateway: document.getElementById('wifi_ap_gateway').value
+      },
+      sta:{
+        ssid: document.getElementById('wifi_sta_ssid').value,
+        password: document.getElementById('wifi_sta_password').value,
+        authmode: document.getElementById('wifi_sta_authmode').value,
+        dhcp: document.getElementById('wifi_sta_dhcp').checked,
+        static_ip: document.getElementById('wifi_sta_static_ip').value,
+        subnet: document.getElementById('wifi_sta_subnet').value,
+        gateway: document.getElementById('wifi_sta_gateway').value
+      }
     }
   };
   fetch('/config', {
@@ -57,18 +88,38 @@ function loadConfigFromServer(){
       document.getElementById('lan_subnet').value = config.lan.subnet;
       document.getElementById('lan_gateway').value = config.lan.gateway;
       document.getElementById('wifi_enabled').checked = config.wifi.enabled;
-      document.getElementById('wifi_ssid').value = config.wifi.ssid;
-      document.getElementById('wifi_password').value = config.wifi.password;
-      document.getElementById('wifi_authmode').value = config.wifi.authmode;
       document.getElementById('wifi_mode').value = config.wifi.mode;
+      document.getElementById('wifi_ap_ssid').value = config.wifi.ap.ssid;
+      document.getElementById('wifi_ap_password').value = config.wifi.ap.password;
+      document.getElementById('wifi_ap_authmode').value = config.wifi.ap.authmode;
+      document.getElementById('wifi_ap_dhcp').checked = config.wifi.ap.dhcp;
+      document.getElementById('wifi_ap_static_ip').value = config.wifi.ap.static_ip;
+      document.getElementById('wifi_ap_subnet').value = config.wifi.ap.subnet;
+      document.getElementById('wifi_ap_gateway').value = config.wifi.ap.gateway;
+      document.getElementById('wifi_sta_ssid').value = config.wifi.sta.ssid;
+      document.getElementById('wifi_sta_password').value = config.wifi.sta.password;
+      document.getElementById('wifi_sta_authmode').value = config.wifi.sta.authmode;
+      document.getElementById('wifi_sta_dhcp').checked = config.wifi.sta.dhcp;
+      document.getElementById('wifi_sta_static_ip').value = config.wifi.sta.static_ip;
+      document.getElementById('wifi_sta_subnet').value = config.wifi.sta.subnet;
+      document.getElementById('wifi_sta_gateway').value = config.wifi.sta.gateway;
       toggleLanFields();
       toggleWifiFields();
+      toggleWifiModeFields();
+      toggleDhcp('wifi_ap');
+      toggleDhcp('wifi_sta');
     });
 }
 document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('lan_dhcp').addEventListener('change', toggleLanFields);
   document.getElementById('wifi_enabled').addEventListener('change', toggleWifiFields);
+  document.getElementById('wifi_mode').addEventListener('change', toggleWifiModeFields);
+  document.getElementById('wifi_ap_dhcp').addEventListener('change', () => toggleDhcp('wifi_ap'));
+  document.getElementById('wifi_sta_dhcp').addEventListener('change', () => toggleDhcp('wifi_sta'));
   toggleLanFields();
   toggleWifiFields();
+  toggleWifiModeFields();
+  toggleDhcp('wifi_ap');
+  toggleDhcp('wifi_sta');
   loadConfigFromServer();
 });


### PR DESCRIPTION
## Summary
- add AP+STA wifi mode with separate settings for each interface
- allow DHCP or static addressing for WiFi AP and STA
- update firmware config and startup to handle dual-mode

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894a24bf3848329a8b4a7f0a5f9caf0