### PR TITLE
Add network socket roles and MQTT topic subscriptions

### DIFF
--- a/firmware/components/um1_config/include/um1_config.h
+++ b/firmware/components/um1_config/include/um1_config.h
@@ -3,6 +3,7 @@
 
 #include <esp_log.h>
 #include <string.h>
+#include <stdbool.h>
 #include "cJSON.h"
 #include "esp_spiffs.h"
 
@@ -58,6 +59,31 @@ typedef struct {
     char server_ip[64];
     int sync_interval_sec;
 } sntp_config_t;
+
+typedef struct {
+    char interface[8];
+    int baudrate;
+    char parity[8];
+    int bits;
+    char protocol[8];
+    char role[8];
+    char ip[16];
+    int port;
+    char topic[64];
+} endpoint_config_t;
+
+typedef struct {
+    endpoint_config_t src;
+    endpoint_config_t dst;
+    bool active;
+} route_config_t;
+
+#define MAX_ROUTES 8
+extern route_config_t global_routes[MAX_ROUTES];
+extern int global_route_count;
+
+bool add_route(route_config_t route);
+bool remove_route(int index);
 
 extern lan_config_t global_lan_config;
 extern um1_wifi_config_t global_wifi_config;

--- a/firmware/components/um1_config/include/um1_config.h
+++ b/firmware/components/um1_config/include/um1_config.h
@@ -41,12 +41,16 @@ typedef struct {
     char broker[64];
     char username[32];
     char password[32];
+    bool tx_enabled;
+    bool rx_enabled;
+    char topic[64];
 } mqtt_config_t;
 
 typedef struct {
     bool enabled;
     char server[64];
     int port;
+    char role[8];
 } stream_config_t;
 
 typedef struct {

--- a/firmware/components/um1_config/um1_config.c
+++ b/firmware/components/um1_config/um1_config.c
@@ -8,6 +8,10 @@ mqtt_config_t global_mqtt_config;
 stream_config_t global_tcp_config;
 stream_config_t global_udp_config;
 sntp_config_t global_sntp_config;
+route_config_t global_routes[MAX_ROUTES];
+int global_route_count = 0;
+
+static void parse_endpoint(endpoint_config_t *ep, cJSON *obj);
 
 void read_config_and_apply(void)
 {
@@ -150,19 +154,89 @@ void read_config_and_apply(void)
                 strcpy(global_udp_config.role, "client");
             }
         }
-	cJSON *sntp = cJSON_GetObjectItem(root, "sntp");
-	if (sntp) {
-	    global_sntp_config.enabled = cJSON_GetObjectItem(sntp, "enabled")->valueint;
-	    strcpy(global_sntp_config.server_ip, cJSON_GetObjectItem(sntp, "server_ip")->valuestring);
-	    global_sntp_config.sync_interval_sec = cJSON_GetObjectItem(sntp, "sync_interval_sec")->valueint;
+        cJSON *sntp = cJSON_GetObjectItem(root, "sntp");
+        if (sntp) {
+            global_sntp_config.enabled = cJSON_GetObjectItem(sntp, "enabled")->valueint;
+            strcpy(global_sntp_config.server_ip, cJSON_GetObjectItem(sntp, "server_ip")->valuestring);
+            global_sntp_config.sync_interval_sec = cJSON_GetObjectItem(sntp, "sync_interval_sec")->valueint;
 
 	    ESP_LOGI("CONFIG", "SNTP: enabled=%d, server_ip=%s, interval=%d",
 	             global_sntp_config.enabled,
-	             global_sntp_config.server_ip,
-	             global_sntp_config.sync_interval_sec);
-	}
+                     global_sntp_config.server_ip,
+                     global_sntp_config.sync_interval_sec);
+        }
+
+        cJSON *routes = cJSON_GetObjectItem(root, "routes");
+        if (routes && cJSON_IsArray(routes)) {
+            int len = cJSON_GetArraySize(routes);
+            global_route_count = len < MAX_ROUTES ? len : MAX_ROUTES;
+            for (int i = 0; i < global_route_count; i++) {
+                cJSON *rt = cJSON_GetArrayItem(routes, i);
+                if (!rt) continue;
+                cJSON *src = cJSON_GetObjectItem(rt, "source");
+                if (src) parse_endpoint(&global_routes[i].src, src);
+                cJSON *dst = cJSON_GetObjectItem(rt, "destination");
+                if (dst) parse_endpoint(&global_routes[i].dst, dst);
+                cJSON *active = cJSON_GetObjectItem(rt, "active");
+                global_routes[i].active = active ? active->valueint : true;
+            }
+        }
 
     cJSON_Delete(root);
     free(data);
+}
+
+static void parse_endpoint(endpoint_config_t *ep, cJSON *obj)
+{
+    if (!ep || !obj) return;
+    memset(ep, 0, sizeof(*ep));
+
+    cJSON *iface = cJSON_GetObjectItem(obj, "interface");
+    if (iface && cJSON_IsString(iface)) {
+        strncpy(ep->interface, iface->valuestring, sizeof(ep->interface));
+    }
+    cJSON *baud = cJSON_GetObjectItem(obj, "baudrate");
+    if (baud) ep->baudrate = baud->valueint;
+    cJSON *parity = cJSON_GetObjectItem(obj, "parity");
+    if (parity && cJSON_IsString(parity)) {
+        strncpy(ep->parity, parity->valuestring, sizeof(ep->parity));
+    }
+    cJSON *bits = cJSON_GetObjectItem(obj, "bits");
+    if (bits) ep->bits = bits->valueint;
+    cJSON *proto = cJSON_GetObjectItem(obj, "protocol");
+    if (proto && cJSON_IsString(proto)) {
+        strncpy(ep->protocol, proto->valuestring, sizeof(ep->protocol));
+    }
+    cJSON *role = cJSON_GetObjectItem(obj, "role");
+    if (role && cJSON_IsString(role)) {
+        strncpy(ep->role, role->valuestring, sizeof(ep->role));
+    }
+    cJSON *ip = cJSON_GetObjectItem(obj, "ip");
+    if (ip && cJSON_IsString(ip)) {
+        strncpy(ep->ip, ip->valuestring, sizeof(ep->ip));
+    }
+    cJSON *port = cJSON_GetObjectItem(obj, "port");
+    if (port) ep->port = port->valueint;
+    cJSON *topic = cJSON_GetObjectItem(obj, "topic");
+    if (topic && cJSON_IsString(topic)) {
+        strncpy(ep->topic, topic->valuestring, sizeof(ep->topic));
+    }
+}
+
+bool add_route(route_config_t route)
+{
+    if (global_route_count >= MAX_ROUTES) return false;
+    global_routes[global_route_count++] = route;
+    return true;
+}
+
+bool remove_route(int index)
+{
+    if (index < 0 || index >= global_route_count) return false;
+    for (int i = index; i < global_route_count - 1; ++i) {
+        global_routes[i] = global_routes[i + 1];
+    }
+    global_route_count--;
+    return true;
 }
 

--- a/firmware/components/um1_config/um1_config.c
+++ b/firmware/components/um1_config/um1_config.c
@@ -103,31 +103,53 @@ void read_config_and_apply(void)
 		global_uart_config[1].stop_bits = cJSON_GetObjectItem(uart2, "stop_bits")->valueint;
 	}
 
-	cJSON *mqtt = cJSON_GetObjectItem(root, "mqtt");
-	if (mqtt) {
-	    global_mqtt_config.enabled = cJSON_GetObjectItem(mqtt, "enabled")->valueint;
-	    strcpy(global_mqtt_config.broker, cJSON_GetObjectItem(mqtt, "broker")->valuestring);
-	    strcpy(global_mqtt_config.username, cJSON_GetObjectItem(mqtt, "username")->valuestring);
-	    strcpy(global_mqtt_config.password, cJSON_GetObjectItem(mqtt, "password")->valuestring);
+        cJSON *mqtt = cJSON_GetObjectItem(root, "mqtt");
+        if (mqtt) {
+            global_mqtt_config.enabled = cJSON_GetObjectItem(mqtt, "enabled")->valueint;
+            strcpy(global_mqtt_config.broker, cJSON_GetObjectItem(mqtt, "broker")->valuestring);
+            strcpy(global_mqtt_config.username, cJSON_GetObjectItem(mqtt, "username")->valuestring);
+            strcpy(global_mqtt_config.password, cJSON_GetObjectItem(mqtt, "password")->valuestring);
+            cJSON *tx_en = cJSON_GetObjectItem(mqtt, "tx_enabled");
+            global_mqtt_config.tx_enabled = tx_en ? tx_en->valueint : false;
+            cJSON *rx_en = cJSON_GetObjectItem(mqtt, "rx_enabled");
+            global_mqtt_config.rx_enabled = rx_en ? rx_en->valueint : false;
+            cJSON *topic = cJSON_GetObjectItem(mqtt, "topic");
+            if (topic) {
+                strcpy(global_mqtt_config.topic, topic->valuestring);
+            } else {
+                global_mqtt_config.topic[0] = '\0';
+            }
 
-	    ESP_LOGI("CONFIG", "MQTT: enabled=%d, broker=%s, user=%s",
-	             global_mqtt_config.enabled,
-	             global_mqtt_config.broker,
-	             global_mqtt_config.username);
-	}
-	cJSON *tcp = cJSON_GetObjectItem(root, "tcp");
-	if (tcp) {
-	    global_tcp_config.enabled = cJSON_GetObjectItem(tcp, "enabled")->valueint;
-	    strcpy(global_tcp_config.server, cJSON_GetObjectItem(tcp, "server")->valuestring);
-	    global_tcp_config.port = cJSON_GetObjectItem(tcp, "port")->valueint;
-	}
+            ESP_LOGI("CONFIG", "MQTT: enabled=%d, broker=%s, user=%s",
+                     global_mqtt_config.enabled,
+                     global_mqtt_config.broker,
+                     global_mqtt_config.username);
+        }
+        cJSON *tcp = cJSON_GetObjectItem(root, "tcp");
+        if (tcp) {
+            global_tcp_config.enabled = cJSON_GetObjectItem(tcp, "enabled")->valueint;
+            strcpy(global_tcp_config.server, cJSON_GetObjectItem(tcp, "server")->valuestring);
+            global_tcp_config.port = cJSON_GetObjectItem(tcp, "port")->valueint;
+            cJSON *role = cJSON_GetObjectItem(tcp, "role");
+            if (role) {
+                strcpy(global_tcp_config.role, role->valuestring);
+            } else {
+                strcpy(global_tcp_config.role, "client");
+            }
+        }
 
-	cJSON *udp = cJSON_GetObjectItem(root, "udp");
-	if (udp) {
-	    global_udp_config.enabled = cJSON_GetObjectItem(udp, "enabled")->valueint;
-	    strcpy(global_udp_config.server, cJSON_GetObjectItem(udp, "server")->valuestring);
-	    global_udp_config.port = cJSON_GetObjectItem(udp, "port")->valueint;
-	}
+        cJSON *udp = cJSON_GetObjectItem(root, "udp");
+        if (udp) {
+            global_udp_config.enabled = cJSON_GetObjectItem(udp, "enabled")->valueint;
+            strcpy(global_udp_config.server, cJSON_GetObjectItem(udp, "server")->valuestring);
+            global_udp_config.port = cJSON_GetObjectItem(udp, "port")->valueint;
+            cJSON *role = cJSON_GetObjectItem(udp, "role");
+            if (role) {
+                strcpy(global_udp_config.role, role->valuestring);
+            } else {
+                strcpy(global_udp_config.role, "client");
+            }
+        }
 	cJSON *sntp = cJSON_GetObjectItem(root, "sntp");
 	if (sntp) {
 	    global_sntp_config.enabled = cJSON_GetObjectItem(sntp, "enabled")->valueint;

--- a/firmware/components/um1_mqtt/CMakeLists.txt
+++ b/firmware/components/um1_mqtt/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(SRCS "um1_mqtt.c"
                     INCLUDE_DIRS "include"
-                    REQUIRES mqtt um1_config
+                    REQUIRES mqtt um1_config driver
                     )
 

--- a/firmware/components/um1_mqtt/um1_mqtt.c
+++ b/firmware/components/um1_mqtt/um1_mqtt.c
@@ -1,4 +1,5 @@
 #include "um1_mqtt.h"
+#include "um1_uart.h"
 
 static const char *TAG = "um1_mqtt";
 esp_mqtt_client_handle_t global_mqtt_client = NULL;
@@ -14,6 +15,10 @@ void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_t event
     switch ((esp_mqtt_event_id_t)event_id) {
     case MQTT_EVENT_CONNECTED:
         ESP_LOGI(TAG, "MQTT_EVENT_CONNECTED");
+        if (global_mqtt_config.rx_enabled && strlen(global_mqtt_config.topic) > 0) {
+            esp_mqtt_client_subscribe(((esp_mqtt_event_handle_t)event_data)->client,
+                                      global_mqtt_config.topic, 1);
+        }
         break;
     case MQTT_EVENT_DISCONNECTED:
         ESP_LOGI(TAG, "MQTT_EVENT_DISCONNECTED");
@@ -28,7 +33,21 @@ void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_t event
         ESP_LOGI(TAG, "MQTT_EVENT_PUBLISHED");
         break;
     case MQTT_EVENT_DATA:
-        ESP_LOGI(TAG, "MQTT_EVENT_DATA");
+        {
+            esp_mqtt_event_handle_t event = event_data;
+            char topic[64];
+            int len = event->topic_len < (int)sizeof(topic) - 1 ? event->topic_len : (int)sizeof(topic) - 1;
+            memcpy(topic, event->topic, len);
+            topic[len] = '\0';
+
+            ESP_LOGI(TAG, "MQTT_EVENT_DATA topic=%s", topic);
+
+            int uart_port = 0;
+            if (sscanf(topic, "uart/%d", &uart_port) == 1) {
+                int port_num = (uart_port == 2) ? UART_PORT_NUM_2 : UART_PORT_NUM_1;
+                uart_write_bytes(port_num, event->data, event->data_len);
+            }
+        }
         break;
     case MQTT_EVENT_ERROR:
         ESP_LOGI(TAG, "MQTT_EVENT_ERROR");

--- a/firmware/components/um1_uart/um1_uart.c
+++ b/firmware/components/um1_uart/um1_uart.c
@@ -1,13 +1,23 @@
 #include "um1_uart.h"
+#include <string.h>
+#include <lwip/sockets.h>
+#include <lwip/inet.h>
 
 /*static const char *TAG = "um1_uart";*/
 
 static int tcp_sock = -1;
+static int tcp_listen_sock = -1;
 static int udp_sock = -1;
 static struct sockaddr_in tcp_dest;
 static struct sockaddr_in udp_dest;
 bool tcp_connected = false;
 bool udp_connected = false;
+
+static void process_stream_buffer(const char *buf, int len);
+static void tcp_client_task(void *arg);
+static void tcp_server_task(void *arg);
+static void udp_client_task(void *arg);
+static void udp_server_task(void *arg);
 
 void start_uart(void){
 	um1_uart_config_t uart1_cfg = global_uart_config[0];
@@ -119,7 +129,7 @@ void send_uart_packet_with_timestamp(int uart_port, const uint8_t *data, size_t 
 
     // MQTT
     esp_mqtt_client_handle_t client = get_mqtt_client_handle();
-    if (client != NULL && global_mqtt_config.enabled) {
+    if (client != NULL && global_mqtt_config.enabled && global_mqtt_config.tx_enabled) {
         char topic[16];
         snprintf(topic, sizeof(topic), "uart/%d", uart_port);
         esp_mqtt_client_publish(client, topic, (const char *)extended_buffer, total_len, 1, 0);
@@ -128,16 +138,35 @@ void send_uart_packet_with_timestamp(int uart_port, const uint8_t *data, size_t 
 
 void init_stream_sockets(void) {
     if (global_tcp_config.enabled) {
-        tcp_sock = socket(AF_INET, SOCK_STREAM, 0);
-        if (tcp_sock >= 0) {
-            tcp_dest.sin_family = AF_INET;
-            tcp_dest.sin_port = htons(global_tcp_config.port);
-            inet_pton(AF_INET, global_tcp_config.server, &tcp_dest.sin_addr);
-            if (connect(tcp_sock, (struct sockaddr *)&tcp_dest, sizeof(tcp_dest)) == 0) {
-                tcp_connected = true;
-            } else {
-                close(tcp_sock);
-                tcp_sock = -1;
+        if (strcmp(global_tcp_config.role, "server") == 0) {
+            tcp_listen_sock = socket(AF_INET, SOCK_STREAM, 0);
+            if (tcp_listen_sock >= 0) {
+                struct sockaddr_in addr = {
+                    .sin_family = AF_INET,
+                    .sin_port = htons(global_tcp_config.port),
+                    .sin_addr.s_addr = htonl(INADDR_ANY)
+                };
+                if (bind(tcp_listen_sock, (struct sockaddr *)&addr, sizeof(addr)) == 0 &&
+                    listen(tcp_listen_sock, 1) == 0) {
+                    xTaskCreate(tcp_server_task, "tcp_server_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+                } else {
+                    close(tcp_listen_sock);
+                    tcp_listen_sock = -1;
+                }
+            }
+        } else {
+            tcp_sock = socket(AF_INET, SOCK_STREAM, 0);
+            if (tcp_sock >= 0) {
+                tcp_dest.sin_family = AF_INET;
+                tcp_dest.sin_port = htons(global_tcp_config.port);
+                inet_pton(AF_INET, global_tcp_config.server, &tcp_dest.sin_addr);
+                if (connect(tcp_sock, (struct sockaddr *)&tcp_dest, sizeof(tcp_dest)) == 0) {
+                    tcp_connected = true;
+                    xTaskCreate(tcp_client_task, "tcp_client_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+                } else {
+                    close(tcp_sock);
+                    tcp_sock = -1;
+                }
             }
         }
     }
@@ -145,14 +174,30 @@ void init_stream_sockets(void) {
     if (global_udp_config.enabled) {
         udp_sock = socket(AF_INET, SOCK_DGRAM, 0);
         if (udp_sock >= 0) {
-            udp_dest.sin_family = AF_INET;
-            udp_dest.sin_port = htons(global_udp_config.port);
-            inet_pton(AF_INET, global_udp_config.server, &udp_dest.sin_addr);
-            if (connect(udp_sock, (struct sockaddr *)&udp_dest, sizeof(udp_dest)) == 0) {
-                udp_connected = true;
+            if (strcmp(global_udp_config.role, "server") == 0) {
+                struct sockaddr_in addr = {
+                    .sin_family = AF_INET,
+                    .sin_port = htons(global_udp_config.port),
+                    .sin_addr.s_addr = htonl(INADDR_ANY)
+                };
+                if (bind(udp_sock, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
+                    udp_connected = true;
+                    xTaskCreate(udp_server_task, "udp_server_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+                } else {
+                    close(udp_sock);
+                    udp_sock = -1;
+                }
             } else {
-                close(udp_sock);
-                udp_sock = -1;
+                udp_dest.sin_family = AF_INET;
+                udp_dest.sin_port = htons(global_udp_config.port);
+                inet_pton(AF_INET, global_udp_config.server, &udp_dest.sin_addr);
+                if (connect(udp_sock, (struct sockaddr *)&udp_dest, sizeof(udp_dest)) == 0) {
+                    udp_connected = true;
+                    xTaskCreate(udp_client_task, "udp_client_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+                } else {
+                    close(udp_sock);
+                    udp_sock = -1;
+                }
             }
         }
     }
@@ -184,6 +229,75 @@ void send_udp_packet(int uart_port, const uint8_t *data, size_t len) {
         udp_sock = -1;
         udp_connected = false;
     }
+}
+
+static void process_stream_buffer(const char *buf, int len) {
+    if (len <= 0) return;
+    if (strncmp(buf, "uart1:", 6) == 0) {
+        uart_write_bytes(UART_PORT_NUM_1, buf + 6, len - 6);
+    } else if (strncmp(buf, "uart2:", 6) == 0) {
+        uart_write_bytes(UART_PORT_NUM_2, buf + 6, len - 6);
+    }
+}
+
+static void tcp_client_task(void *arg) {
+    char buffer[BUF_SIZE];
+    while (1) {
+        int len = recv(tcp_sock, buffer, sizeof(buffer), 0);
+        if (len <= 0) break;
+        process_stream_buffer(buffer, len);
+    }
+    close(tcp_sock);
+    tcp_sock = -1;
+    tcp_connected = false;
+    vTaskDelete(NULL);
+}
+
+static void tcp_server_task(void *arg) {
+    char buffer[BUF_SIZE];
+    while (1) {
+        int client = accept(tcp_listen_sock, NULL, NULL);
+        if (client < 0) continue;
+        tcp_sock = client;
+        tcp_connected = true;
+        while (1) {
+            int len = recv(client, buffer, sizeof(buffer), 0);
+            if (len <= 0) break;
+            process_stream_buffer(buffer, len);
+        }
+        close(client);
+        tcp_sock = -1;
+        tcp_connected = false;
+    }
+}
+
+static void udp_client_task(void *arg) {
+    char buffer[BUF_SIZE];
+    while (1) {
+        int len = recv(udp_sock, buffer, sizeof(buffer), 0);
+        if (len <= 0) break;
+        process_stream_buffer(buffer, len);
+    }
+    close(udp_sock);
+    udp_sock = -1;
+    udp_connected = false;
+    vTaskDelete(NULL);
+}
+
+static void udp_server_task(void *arg) {
+    char buffer[BUF_SIZE];
+    struct sockaddr_in src_addr;
+    socklen_t addrlen = sizeof(src_addr);
+    while (1) {
+        int len = recvfrom(udp_sock, buffer, sizeof(buffer), 0,
+                           (struct sockaddr *)&src_addr, &addrlen);
+        if (len < 0) break;
+        process_stream_buffer(buffer, len);
+    }
+    close(udp_sock);
+    udp_sock = -1;
+    udp_connected = false;
+    vTaskDelete(NULL);
 }
 
 uint64_t reverse_bytes_u64(uint64_t value) {

--- a/web/src/config.json
+++ b/web/src/config.json
@@ -66,5 +66,23 @@
     "enabled": true,
     "server_ip": "pool.ntp.org",
     "sync_interval_sec": 3600
-  }
+  },
+  "routes": [
+    {
+      "source": {
+        "interface": "UART1",
+        "baudrate": 115200,
+        "parity": "none",
+        "bits": 8
+      },
+      "destination": {
+        "interface": "LAN",
+        "protocol": "TCP",
+        "role": "client",
+        "ip": "192.168.0.135",
+        "port": 1234
+      },
+      "active": true
+    }
+  ]
 }

--- a/web/src/config.json
+++ b/web/src/config.json
@@ -46,17 +46,21 @@
     "broker": "mqtt://uhcloud.ru",
     "username": "igtrefilov",
     "password": "estrella",
-    "tx_enabled": true
+    "tx_enabled": true,
+    "rx_enabled": false,
+    "topic": "uart/#"
   },
   "tcp": {
     "enabled": true,
     "server": "192.168.1.100",
-    "port": 1234
+    "port": 1234,
+    "role": "client"
   },
   "udp": {
     "enabled": false,
     "server": "",
-    "port": 0
+    "port": 0,
+    "role": "client"
   },
   "sntp": {
     "enabled": true,

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -13,6 +13,7 @@
       <a href="/index.html" class="active">Главная</a>
       <a href="/settings/settings.html">Настройки</a>
       <a href="/network/network.html">Сеть</a>
+      <a href="/routing/routing.html">Маршруты</a>
       <a href="/update/update.html">Обновление</a>
       <a href="/about/about.html">О системе</a>
       <a href="#" id="logout_btn">Выход</a>

--- a/web/src/network/network.html
+++ b/web/src/network/network.html
@@ -13,6 +13,7 @@
       <a href="/index.html">Главная</a>
       <a href="/settings/settings.html">Настройки</a>
       <a href="/network/network.html" class="active">Сеть</a>
+      <a href="/routing/routing.html">Маршруты</a>
       <a href="/update/update.html">Обновление</a>
       <a href="/about/about.html">О системе</a>
       <a href="#" id="logout_btn">Выход</a>

--- a/web/src/routing/routing.html
+++ b/web/src/routing/routing.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
   <meta charset="UTF-8" />
-  <title>О системе — УМ1</title>
+  <title>Маршруты — УМ1</title>
   <link rel="icon" type="image/png" href="/favicon.png" />
   <link rel="stylesheet" href="/style.css" />
 </head>
@@ -13,20 +13,32 @@
       <a href="/index.html">Главная</a>
       <a href="/settings/settings.html">Настройки</a>
       <a href="/network/network.html">Сеть</a>
-      <a href="/routing/routing.html">Маршруты</a>
+      <a href="/routing/routing.html" class="active">Маршруты</a>
       <a href="/update/update.html">Обновление</a>
-      <a href="/about/about.html" class="active">О системе</a>
+      <a href="/about/about.html">О системе</a>
       <a href="#" id="logout_btn">Выход</a>
     </nav>
   </header>
   <div class="container">
     <div id="notif" class="notification"></div>
     <div class="card">
-      <h2>Информация о системе</h2>
-      <div id="sysinfo">Загрузка...</div>
+      <h3>Routing Table</h3>
+      <table class="settings-table" id="route_table">
+        <thead>
+          <tr>
+            <th>Source</th>
+            <th>Destination</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody id="route_body"></tbody>
+      </table>
+      <button id="add_route">Добавить</button>
+      <button id="save_routes">Сохранить</button>
     </div>
   </div>
   <script src="/app.js"></script>
-  <script src="/about/about.js"></script>
+  <script src="/routing/routing.js"></script>
+  <script>loadRoutes();</script>
 </body>
 </html>

--- a/web/src/routing/routing.js
+++ b/web/src/routing/routing.js
@@ -1,0 +1,173 @@
+function createInterfaceSelect(cls, value=''){
+  const sel = document.createElement('select');
+  sel.className = cls;
+  ['','UART1','UART2','LAN','AP','STA'].forEach(v=>{
+    const opt = document.createElement('option');
+    opt.value = v;
+    opt.textContent = v || '—';
+    if(v===value) opt.selected = true;
+    sel.appendChild(opt);
+  });
+  return sel;
+}
+
+function updateEndpointExtra(sel){
+  const prefix = sel.classList.contains('src-if') ? 'src' : 'dst';
+  const container = sel.parentElement.querySelector('.'+prefix+'-extra');
+  const val = sel.value;
+  let html = '';
+  if(val==='UART1' || val==='UART2'){
+    html = `Baudrate: <input type="number" class="${prefix}-baudrate" value="115200"/> `+
+           `Parity: <select class="${prefix}-parity"><option value="none">none</option><option value="even">even</option><option value="odd">odd</option></select> `+
+           `Bits: <select class="${prefix}-bits"><option value="8">8</option><option value="7">7</option></select>`;
+  }else if(['LAN','AP','STA'].includes(val)){
+    html = `Protocol: <select class="${prefix}-protocol"><option value="TCP">TCP</option><option value="UDP">UDP</option><option value="MQTT">MQTT</option></select> <span class="${prefix}-proto-extra"></span>`;
+  }
+  container.innerHTML = html;
+  if(['LAN','AP','STA'].includes(val)){
+    const psel = container.querySelector('.'+prefix+'-protocol');
+    const updateProto = ()=>{
+      const pv = psel.value;
+      const protoDiv = container.querySelector('.'+prefix+'-proto-extra');
+      let phtml='';
+      if(pv==='MQTT'){
+        phtml = `Role: <select class="${prefix}-role"><option value="publish">Publish</option><option value="subscribe">Subscribe</option></select> Topic: <input type="text" class="${prefix}-topic"/>`;
+      }else{
+        phtml = `Role: <select class="${prefix}-role"><option value="client">Client</option><option value="server">Server</option></select> IP: <input type="text" class="${prefix}-ip"/> Port: <input type="number" class="${prefix}-port"/>`;
+      }
+      protoDiv.innerHTML = phtml;
+    };
+    psel.addEventListener('change', updateProto);
+    updateProto();
+  }
+}
+
+function addRow(route){
+  const tbody = document.getElementById('route_body');
+  const tr = document.createElement('tr');
+
+  const tdSrc = document.createElement('td');
+  const srcSel = createInterfaceSelect('src-if', route?.source?.interface);
+  tdSrc.appendChild(srcSel);
+  const srcExtra = document.createElement('div');
+  srcExtra.className = 'src-extra';
+  tdSrc.appendChild(srcExtra);
+  tr.appendChild(tdSrc);
+
+  const tdDst = document.createElement('td');
+  const dstSel = createInterfaceSelect('dst-if', route?.destination?.interface);
+  tdDst.appendChild(dstSel);
+  const dstExtra = document.createElement('div');
+  dstExtra.className = 'dst-extra';
+  tdDst.appendChild(dstExtra);
+  tr.appendChild(tdDst);
+
+  const tdAct = document.createElement('td');
+  const rm = document.createElement('button');
+  rm.textContent = 'Удалить';
+  rm.addEventListener('click', ()=>tr.remove());
+  tdAct.appendChild(rm);
+  tr.appendChild(tdAct);
+
+  tbody.appendChild(tr);
+  srcSel.addEventListener('change', ()=>updateEndpointExtra(srcSel));
+  dstSel.addEventListener('change', ()=>updateEndpointExtra(dstSel));
+  if(route) {
+    updateEndpointExtra(srcSel);
+    updateEndpointExtra(dstSel);
+    if(route.source){
+      if(route.source.baudrate) tr.querySelector('.src-baudrate').value = route.source.baudrate;
+      if(route.source.parity) tr.querySelector('.src-parity').value = route.source.parity;
+      if(route.source.bits) tr.querySelector('.src-bits').value = route.source.bits;
+      if(route.source.protocol){
+        tr.querySelector('.src-protocol').value = route.source.protocol;
+        updateEndpointExtra(srcSel); // rerender proto
+        const srcProto = tr.querySelector('.src-protocol');
+        srcProto.value = route.source.protocol;
+        srcProto.dispatchEvent(new Event('change'));
+        const protoDiv = tr.querySelector('.src-proto-extra');
+        if(route.source.role) protoDiv.querySelector('.src-role').value = route.source.role;
+        if(route.source.ip) protoDiv.querySelector('.src-ip').value = route.source.ip;
+        if(route.source.port) protoDiv.querySelector('.src-port').value = route.source.port;
+        if(route.source.topic) protoDiv.querySelector('.src-topic').value = route.source.topic;
+      }
+    }
+    if(route.destination){
+      if(route.destination.baudrate) tr.querySelector('.dst-baudrate').value = route.destination.baudrate;
+      if(route.destination.parity) tr.querySelector('.dst-parity').value = route.destination.parity;
+      if(route.destination.bits) tr.querySelector('.dst-bits').value = route.destination.bits;
+      if(route.destination.protocol){
+        tr.querySelector('.dst-protocol').value = route.destination.protocol;
+        updateEndpointExtra(dstSel);
+        const dstProto = tr.querySelector('.dst-protocol');
+        dstProto.value = route.destination.protocol;
+        dstProto.dispatchEvent(new Event('change'));
+        const protoDiv = tr.querySelector('.dst-proto-extra');
+        if(route.destination.role) protoDiv.querySelector('.dst-role').value = route.destination.role;
+        if(route.destination.ip) protoDiv.querySelector('.dst-ip').value = route.destination.ip;
+        if(route.destination.port) protoDiv.querySelector('.dst-port').value = route.destination.port;
+        if(route.destination.topic) protoDiv.querySelector('.dst-topic').value = route.destination.topic;
+      }
+    }
+  }
+}
+
+function collectRoutes(){
+  const routes = [];
+  document.querySelectorAll('#route_body tr').forEach(tr=>{
+    const srcIf = tr.querySelector('.src-if').value;
+    const dstIf = tr.querySelector('.dst-if').value;
+    const route = { source:{ interface: srcIf }, destination:{ interface: dstIf }, active:true };
+    if(srcIf.startsWith('UART')){
+      route.source.baudrate = parseInt(tr.querySelector('.src-baudrate').value)||0;
+      route.source.parity = tr.querySelector('.src-parity').value;
+      route.source.bits = parseInt(tr.querySelector('.src-bits').value)||0;
+    }else if(['LAN','AP','STA'].includes(srcIf)){
+      route.source.protocol = tr.querySelector('.src-protocol').value;
+      const div = tr.querySelector('.src-proto-extra');
+      route.source.role = div.querySelector('.src-role').value;
+      if(route.source.protocol === 'MQTT'){
+        route.source.topic = div.querySelector('.src-topic').value;
+      }else{
+        route.source.ip = div.querySelector('.src-ip').value;
+        route.source.port = parseInt(div.querySelector('.src-port').value)||0;
+      }
+    }
+    if(dstIf.startsWith('UART')){
+      route.destination.baudrate = parseInt(tr.querySelector('.dst-baudrate').value)||0;
+      route.destination.parity = tr.querySelector('.dst-parity').value;
+      route.destination.bits = parseInt(tr.querySelector('.dst-bits').value)||0;
+    }else if(['LAN','AP','STA'].includes(dstIf)){
+      route.destination.protocol = tr.querySelector('.dst-protocol').value;
+      const div = tr.querySelector('.dst-proto-extra');
+      route.destination.role = div.querySelector('.dst-role').value;
+      if(route.destination.protocol === 'MQTT'){
+        route.destination.topic = div.querySelector('.dst-topic').value;
+      }else{
+        route.destination.ip = div.querySelector('.dst-ip').value;
+        route.destination.port = parseInt(div.querySelector('.dst-port').value)||0;
+      }
+    }
+    routes.push(route);
+  });
+  return routes;
+}
+
+function loadRoutes(){
+  fetch('/api/config')
+    .then(r=>r.json())
+    .then(cfg=>{
+      (cfg.routes||[]).forEach(r=>addRow(r));
+    })
+    .catch(_=>{});
+}
+
+const addBtn = document.getElementById('add_route');
+if(addBtn) addBtn.addEventListener('click', ()=>addRow());
+const saveBtn = document.getElementById('save_routes');
+if(saveBtn) saveBtn.addEventListener('click', ()=>{
+  const routes = collectRoutes();
+  fetch('/config', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({routes})})
+    .then(r=>{ if(r.ok) notify('✅ Маршруты сохранены'); else notify('❌ Ошибка', 'error'); })
+    .catch(_=>notify('❌ Ошибка соединения', 'error'));
+});

--- a/web/src/settings/settings.html
+++ b/web/src/settings/settings.html
@@ -13,6 +13,7 @@
       <a href="/index.html">Главная</a>
       <a href="/settings/settings.html" class="active">Настройки</a>
       <a href="/network/network.html">Сеть</a>
+      <a href="/routing/routing.html">Маршруты</a>
       <a href="/update/update.html">Обновление</a>
       <a href="/about/about.html">О системе</a>
       <a href="#" id="logout_btn">Выход</a>

--- a/web/src/update/update.html
+++ b/web/src/update/update.html
@@ -13,6 +13,7 @@
       <a href="/index.html">Главная</a>
       <a href="/settings/settings.html">Настройки</a>
       <a href="/network/network.html">Сеть</a>
+      <a href="/routing/routing.html">Маршруты</a>
       <a href="/update/update.html" class="active">Обновление</a>
       <a href="/about/about.html">О системе</a>
       <a href="#" id="logout_btn">Выход</a>


### PR DESCRIPTION
## Summary
- allow MQTT configuration for publish and subscribe topics
- handle TCP/UDP sockets in server or client mode and forward incoming data to UART
- extend default config with new MQTT and socket options

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895b5e5e92c83299ac51533ab16308a