### PR TITLE
feat: add routing-aware wifi tcp servers

### DIFF
--- a/firmware/components/um1_lan/um1_lan.c
+++ b/firmware/components/um1_lan/um1_lan.c
@@ -3,6 +3,7 @@
 #include <sys/stat.h>
 #include <dirent.h>
 #include <unistd.h>
+#include "um1_uart.h"
 
 #define TCP_PORT  3333
 #define LISTEN_BACKLOG 5
@@ -79,6 +80,7 @@ void handle_client(int client_sock) {
     }
     cmd[len] = '\0';
     ESP_LOGI(TAG, "Received cmd: '%s'", cmd);
+    route_data("LAN", (uint8_t *)cmd, len);
 
     if (strncmp(cmd, "TREE ", 5) == 0) {
         char dir[128];
@@ -143,6 +145,7 @@ void handle_client(int client_sock) {
                 int to_read = rem > CHUNK_SZ ? CHUNK_SZ : rem;
                 int r = recv(client_sock, buf, to_read, 0);
                 if (r <= 0) break;
+                route_data("LAN", buf, r);
                 fwrite(buf, 1, r, f);
                 rem -= r;
             }
@@ -170,6 +173,7 @@ void handle_client(int client_sock) {
                         int r = fread(buf, 1, to_read, f);
                         if (r <= 0) break;
                         send(client_sock, buf, r, 0);
+                        route_data("LAN", buf, r);
                         sent += r;
                     }
                     fclose(f);

--- a/firmware/components/um1_uart/include/um1_uart.h
+++ b/firmware/components/um1_uart/include/um1_uart.h
@@ -28,6 +28,7 @@ void init_stream_sockets(void);
 void send_uart_packet_with_timestamp(int uart_port, const uint8_t *data, size_t len);
 void send_tcp_packet(int uart_port, const uint8_t *data, size_t len);
 void send_udp_packet(int uart_port, const uint8_t *data, size_t len);
+void route_data(const char *src_if, const uint8_t *data, size_t len);
 uint64_t reverse_bytes_u64(uint64_t value);
 
 extern bool tcp_connected;

--- a/firmware/components/um1_uart/um1_uart.c
+++ b/firmware/components/um1_uart/um1_uart.c
@@ -15,7 +15,7 @@ bool tcp_connected = false;
 bool udp_connected = false;
 
 static void process_stream_buffer(const char *buf, int len);
-static void route_data(const char *src_if, const uint8_t *data, size_t len);
+void route_data(const char *src_if, const uint8_t *data, size_t len);
 static void tcp_client_task(void *arg);
 static void tcp_server_task(void *arg);
 static void udp_client_task(void *arg);
@@ -225,7 +225,7 @@ void send_udp_packet(int uart_port, const uint8_t *data, size_t len) {
     }
 }
 
-static void route_data(const char *src_if, const uint8_t *data, size_t len) {
+void route_data(const char *src_if, const uint8_t *data, size_t len) {
     int src_uart_port = -1;
     if (strcasecmp(src_if, "UART1") == 0) src_uart_port = UART_PORT_NUM_1;
     else if (strcasecmp(src_if, "UART2") == 0) src_uart_port = UART_PORT_NUM_2;
@@ -235,7 +235,9 @@ static void route_data(const char *src_if, const uint8_t *data, size_t len) {
         if (!r->active) continue;
         if (strcasecmp(r->src.interface, src_if) != 0) continue;
 
-        if (strcasecmp(r->dst.interface, "LAN") == 0) {
+        if (strcasecmp(r->dst.interface, "LAN") == 0 ||
+            strcasecmp(r->dst.interface, "AP") == 0 ||
+            strcasecmp(r->dst.interface, "STA") == 0) {
             if (global_tcp_config.enabled) {
                 send_tcp_packet(src_uart_port, data, len);
             }

--- a/firmware/components/um1_wifi/CMakeLists.txt
+++ b/firmware/components/um1_wifi/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(SRCS um1_wifi.c
                     INCLUDE_DIRS "include"
-                    REQUIRES esp_wifi nvs_flash um1_config
+                    REQUIRES esp_wifi nvs_flash um1_config um1_uart
                     )
 

--- a/firmware/components/um1_wifi/um1_wifi.c
+++ b/firmware/components/um1_wifi/um1_wifi.c
@@ -1,4 +1,5 @@
 #include "um1_wifi.h"
+#include "um1_uart.h"
 
 #define TAG "um1_wifi"
 #define TCP_PORT 4444
@@ -7,8 +8,8 @@
 static esp_netif_t *wifi_ap_netif = NULL;
 static esp_netif_t *wifi_sta_netif = NULL;
 
-/* ===== AP MODE ONLY: TCP Server ===== */
-static void wifi_tcp_server_task(void *pvParameters)
+/* ===== AP MODE: TCP Server ===== */
+static void wifi_ap_tcp_server_task(void *pvParameters)
 {
     esp_netif_ip_info_t ip_info;
     ESP_ERROR_CHECK(esp_netif_get_ip_info(wifi_ap_netif, &ip_info));
@@ -42,7 +43,7 @@ static void wifi_tcp_server_task(void *pvParameters)
         return;
     }
 
-    ESP_LOGI(TAG, "TCP server listening on port %d", TCP_PORT);
+    ESP_LOGI(TAG, "AP TCP server listening on port %d", TCP_PORT);
 
     while (1) {
         struct sockaddr_in client_addr;
@@ -53,11 +54,75 @@ static void wifi_tcp_server_task(void *pvParameters)
             break;
         }
 
-        ESP_LOGI(TAG, "Accepted connection from %s:%d",
+        ESP_LOGI(TAG, "AP client from %s:%d",
                  inet_ntoa(client_addr.sin_addr), ntohs(client_addr.sin_port));
 
-        const char *resp = "Hello from ESP32 WiFi AP TCP server!\r\n";
-        send(client_sock, resp, strlen(resp), 0);
+        uint8_t rx_buffer[1024];
+        int len;
+        while ((len = recv(client_sock, rx_buffer, sizeof(rx_buffer), 0)) > 0) {
+            route_data("AP", rx_buffer, len);
+        }
+        close(client_sock);
+    }
+
+    close(listen_sock);
+    vTaskDelete(NULL);
+}
+
+/* ===== STA MODE: TCP Server ===== */
+static void wifi_sta_tcp_server_task(void *pvParameters)
+{
+    esp_netif_ip_info_t ip_info;
+    ESP_ERROR_CHECK(esp_netif_get_ip_info(wifi_sta_netif, &ip_info));
+
+    int listen_sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    if (listen_sock < 0) {
+        ESP_LOGE(TAG, "Unable to create socket: errno %d", errno);
+        vTaskDelete(NULL);
+        return;
+    }
+
+    struct sockaddr_in server_addr = {
+        .sin_family = AF_INET,
+        .sin_addr.s_addr = ip_info.ip.addr,
+        .sin_port = htons(TCP_PORT),
+    };
+
+    int err = bind(listen_sock, (struct sockaddr *)&server_addr, sizeof(server_addr));
+    if (err < 0) {
+        ESP_LOGE(TAG, "Socket unable to bind: errno %d", errno);
+        close(listen_sock);
+        vTaskDelete(NULL);
+        return;
+    }
+
+    err = listen(listen_sock, LISTEN_BACKLOG);
+    if (err < 0) {
+        ESP_LOGE(TAG, "Error during listen: errno %d", errno);
+        close(listen_sock);
+        vTaskDelete(NULL);
+        return;
+    }
+
+    ESP_LOGI(TAG, "STA TCP server listening on port %d", TCP_PORT);
+
+    while (1) {
+        struct sockaddr_in client_addr;
+        socklen_t socklen = sizeof(client_addr);
+        int client_sock = accept(listen_sock, (struct sockaddr *)&client_addr, &socklen);
+        if (client_sock < 0) {
+            ESP_LOGE(TAG, "Unable to accept connection: errno %d", errno);
+            break;
+        }
+
+        ESP_LOGI(TAG, "STA client from %s:%d",
+                 inet_ntoa(client_addr.sin_addr), ntohs(client_addr.sin_port));
+
+        uint8_t rx_buffer[1024];
+        int len;
+        while ((len = recv(client_sock, rx_buffer, sizeof(rx_buffer), 0)) > 0) {
+            route_data("STA", rx_buffer, len);
+        }
         close(client_sock);
     }
 
@@ -76,7 +141,7 @@ static void wifi_event_handler_ap(void *arg, esp_event_base_t event_base, int32_
         ESP_LOGI(TAG, "AP: Station " MACSTR " left, AID=%d", MAC2STR(event->mac), event->aid);
     } else if (event_id == WIFI_EVENT_AP_START) {
         ESP_LOGI(TAG, "AP started");
-        xTaskCreate(wifi_tcp_server_task, "tcp_ap", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+        xTaskCreate(wifi_ap_tcp_server_task, "tcp_ap", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
     }
 }
 
@@ -90,6 +155,7 @@ static void wifi_event_handler_sta(void *arg, esp_event_base_t event_base, int32
     } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
         ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
         ESP_LOGI(TAG, "STA: Got IP: " IPSTR, IP2STR(&event->ip_info.ip));
+        xTaskCreate(wifi_sta_tcp_server_task, "tcp_sta", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
     }
 }
 


### PR DESCRIPTION
## Summary
- expose routing helper and extend for LAN/AP/STA endpoints
- route LAN file server traffic through routing table
- add WiFi AP/STA TCP servers that forward data via routing rules

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install esp-idf` *(fails: no matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_6895d411aac483299fb8ca035cc433c3