### PR TITLE
Refactor socket handling into LAN component

### DIFF
--- a/firmware/components/um1_http_server/um1_http_server.c
+++ b/firmware/components/um1_http_server/um1_http_server.c
@@ -1,4 +1,5 @@
 #include "um1_http_server.h"
+#include "um1_lan.h"
 
 #define MAX_SUBSCRIBERS 10
 #define UPLOAD_BUFFER_SIZE  1024

--- a/firmware/components/um1_lan/include/um1_lan.h
+++ b/firmware/components/um1_lan/include/um1_lan.h
@@ -12,6 +12,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "stddef.h"
+#include <stdbool.h>
 #include "esp_netif.h"
 #include "esp_log.h"
 
@@ -21,5 +22,11 @@
 void handle_client(int client_sock);
 void tcp_lan_server_task(void *pvParameters);
 void udp_lan_server_task(void *pvParameters);
+void init_stream_sockets(void);
+void send_tcp_packet(int uart_port, const uint8_t *data, size_t len);
+void send_udp_packet(int uart_port, const uint8_t *data, size_t len);
+
+extern bool tcp_connected;
+extern bool udp_connected;
 
 #endif // UM1_LAN_H

--- a/firmware/components/um1_lan/start_lan.c
+++ b/firmware/components/um1_lan/start_lan.c
@@ -15,7 +15,6 @@
 #include "start_lan.h"
 #include "um1_lan.h"
 #include "um1_config.h"
-#include "um1_uart.h"
 
 static const char *TAG = "eth_if";
 

--- a/firmware/components/um1_lan/um1_lan.c
+++ b/firmware/components/um1_lan/um1_lan.c
@@ -3,6 +3,9 @@
 #include <sys/stat.h>
 #include <dirent.h>
 #include <unistd.h>
+#include <lwip/sockets.h>
+#include <lwip/inet.h>
+#include <strings.h>
 #include "um1_uart.h"
 
 #define TCP_PORT  3333
@@ -13,6 +16,20 @@
 
 
 static const char *TAG = "eth_if_tasks";
+
+static int tcp_sock = -1;
+static int tcp_listen_sock = -1;
+static int udp_sock = -1;
+static struct sockaddr_in tcp_dest;
+static struct sockaddr_in udp_dest;
+bool tcp_connected = false;
+bool udp_connected = false;
+
+static void process_stream_buffer(const char *buf, int len);
+static void tcp_client_task(void *arg);
+static void tcp_server_task(void *arg);
+static void udp_client_task(void *arg);
+static void udp_server_task(void *arg);
 
 static void send_text(int sock, const char *fmt, ...) {
     char buf[256];
@@ -69,6 +86,184 @@ static void rmdir_recursive(const char *base_path, int sock) {
     }
     closedir(d);
     rmdir(base_path);
+}
+
+static void process_stream_buffer(const char *buf, int len) {
+    if (len <= 0) return;
+    if (strncmp(buf, "uart1:", 6) == 0) {
+        uart_write_bytes(UART_PORT_NUM_1, buf + 6, len - 6);
+    } else if (strncmp(buf, "uart2:", 6) == 0) {
+        uart_write_bytes(UART_PORT_NUM_2, buf + 6, len - 6);
+    }
+}
+
+void init_stream_sockets(void) {
+    if (global_tcp_config.enabled) {
+        if (strcmp(global_tcp_config.role, "server") == 0) {
+            tcp_listen_sock = socket(AF_INET, SOCK_STREAM, 0);
+            if (tcp_listen_sock >= 0) {
+                struct sockaddr_in addr = {
+                    .sin_family = AF_INET,
+                    .sin_port = htons(global_tcp_config.port),
+                    .sin_addr.s_addr = htonl(INADDR_ANY)
+                };
+                if (bind(tcp_listen_sock, (struct sockaddr *)&addr, sizeof(addr)) == 0 &&
+                    listen(tcp_listen_sock, 1) == 0) {
+                    xTaskCreate(tcp_server_task, "tcp_server_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+                } else {
+                    close(tcp_listen_sock);
+                    tcp_listen_sock = -1;
+                }
+            }
+        } else {
+            tcp_sock = socket(AF_INET, SOCK_STREAM, 0);
+            if (tcp_sock >= 0) {
+                tcp_dest.sin_family = AF_INET;
+                tcp_dest.sin_port = htons(global_tcp_config.port);
+                inet_pton(AF_INET, global_tcp_config.server, &tcp_dest.sin_addr);
+                if (connect(tcp_sock, (struct sockaddr *)&tcp_dest, sizeof(tcp_dest)) == 0) {
+                    tcp_connected = true;
+                    xTaskCreate(tcp_client_task, "tcp_client_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+                } else {
+                    close(tcp_sock);
+                    tcp_sock = -1;
+                }
+            }
+        }
+    }
+
+    if (global_udp_config.enabled) {
+        udp_sock = socket(AF_INET, SOCK_DGRAM, 0);
+        if (udp_sock >= 0) {
+            if (strcmp(global_udp_config.role, "server") == 0) {
+                struct sockaddr_in addr = {
+                    .sin_family = AF_INET,
+                    .sin_port = htons(global_udp_config.port),
+                    .sin_addr.s_addr = htonl(INADDR_ANY)
+                };
+                if (bind(udp_sock, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
+                    udp_connected = true;
+                    xTaskCreate(udp_server_task, "udp_server_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+                } else {
+                    close(udp_sock);
+                    udp_sock = -1;
+                }
+            } else {
+                udp_dest.sin_family = AF_INET;
+                udp_dest.sin_port = htons(global_udp_config.port);
+                inet_pton(AF_INET, global_udp_config.server, &udp_dest.sin_addr);
+                if (connect(udp_sock, (struct sockaddr *)&udp_dest, sizeof(udp_dest)) == 0) {
+                    udp_connected = true;
+                    xTaskCreate(udp_client_task, "udp_client_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+                } else {
+                    close(udp_sock);
+                    udp_sock = -1;
+                }
+            }
+        }
+    }
+}
+
+void send_tcp_packet(int uart_port, const uint8_t *data, size_t len) {
+    if (!tcp_connected) return;
+
+    char buffer[BUF_SIZE + 16];
+    int offset = 0;
+    if (uart_port >= 0) {
+        offset = snprintf(buffer, sizeof(buffer), "uart%d:", uart_port);
+    }
+    if (offset + len > sizeof(buffer)) len = sizeof(buffer) - offset;
+    memcpy(buffer + offset, data, len);
+    if (send(tcp_sock, buffer, offset + len, 0) < 0) {
+        close(tcp_sock);
+        tcp_sock = -1;
+        tcp_connected = false;
+    }
+}
+
+void send_udp_packet(int uart_port, const uint8_t *data, size_t len) {
+    if (!udp_connected) return;
+
+    char buffer[BUF_SIZE + 16];
+    int offset = 0;
+    if (uart_port >= 0) {
+        offset = snprintf(buffer, sizeof(buffer), "uart%d:", uart_port);
+    }
+    if (offset + len > sizeof(buffer)) len = sizeof(buffer) - offset;
+    memcpy(buffer + offset, data, len);
+    if (send(udp_sock, buffer, offset + len, 0) < 0) {
+        close(udp_sock);
+        udp_sock = -1;
+        udp_connected = false;
+    }
+}
+
+static void tcp_client_task(void *arg) {
+    char buffer[BUF_SIZE];
+    while (1) {
+        int len = recv(tcp_sock, buffer, sizeof(buffer), 0);
+        if (len <= 0) break;
+        route_data("LAN", (uint8_t *)buffer, len);
+        route_data("AP", (uint8_t *)buffer, len);
+        process_stream_buffer(buffer, len);
+    }
+    close(tcp_sock);
+    tcp_sock = -1;
+    tcp_connected = false;
+    vTaskDelete(NULL);
+}
+
+static void tcp_server_task(void *arg) {
+    char buffer[BUF_SIZE];
+    while (1) {
+        int client = accept(tcp_listen_sock, NULL, NULL);
+        if (client < 0) continue;
+        tcp_sock = client;
+        tcp_connected = true;
+        while (1) {
+            int len = recv(client, buffer, sizeof(buffer), 0);
+            if (len <= 0) break;
+            route_data("LAN", (uint8_t *)buffer, len);
+            route_data("AP", (uint8_t *)buffer, len);
+            process_stream_buffer(buffer, len);
+        }
+        close(client);
+        tcp_sock = -1;
+        tcp_connected = false;
+    }
+}
+
+static void udp_client_task(void *arg) {
+    char buffer[BUF_SIZE];
+    while (1) {
+        int len = recv(udp_sock, buffer, sizeof(buffer), 0);
+        if (len <= 0) break;
+        route_data("LAN", (uint8_t *)buffer, len);
+        route_data("AP", (uint8_t *)buffer, len);
+        process_stream_buffer(buffer, len);
+    }
+    close(udp_sock);
+    udp_sock = -1;
+    udp_connected = false;
+    vTaskDelete(NULL);
+}
+
+static void udp_server_task(void *arg) {
+    char buffer[BUF_SIZE];
+    struct sockaddr_in src_addr;
+    socklen_t addrlen = sizeof(src_addr);
+    while (1) {
+        int len = recvfrom(udp_sock, buffer, sizeof(buffer), 0,
+                           (struct sockaddr *)&src_addr, &addrlen);
+        if (len < 0) break;
+        route_data("LAN", (uint8_t *)buffer, len);
+        route_data("AP", (uint8_t *)buffer, len);
+        process_stream_buffer(buffer, len);
+    }
+    close(udp_sock);
+    udp_sock = -1;
+    udp_connected = false;
+    vTaskDelete(NULL);
 }
 
 void handle_client(int client_sock) {

--- a/firmware/components/um1_uart/include/um1_uart.h
+++ b/firmware/components/um1_uart/include/um1_uart.h
@@ -24,12 +24,6 @@
 void start_uart(void);
 void uart1_task(void *arg);
 void uart2_task(void *arg);
-void init_stream_sockets(void);
 void send_uart_packet_with_timestamp(int uart_port, const uint8_t *data, size_t len);
-void send_tcp_packet(int uart_port, const uint8_t *data, size_t len);
-void send_udp_packet(int uart_port, const uint8_t *data, size_t len);
 void route_data(const char *src_if, const uint8_t *data, size_t len);
 uint64_t reverse_bytes_u64(uint64_t value);
-
-extern bool tcp_connected;
-extern bool udp_connected;

--- a/firmware/components/um1_uart/um1_uart.c
+++ b/firmware/components/um1_uart/um1_uart.c
@@ -1,25 +1,11 @@
 #include "um1_uart.h"
+#include "um1_lan.h"
 #include <string.h>
-#include <lwip/sockets.h>
-#include <lwip/inet.h>
 #include <strings.h>
 
 /*static const char *TAG = "um1_uart";*/
 
-static int tcp_sock = -1;
-static int tcp_listen_sock = -1;
-static int udp_sock = -1;
-static struct sockaddr_in tcp_dest;
-static struct sockaddr_in udp_dest;
-bool tcp_connected = false;
-bool udp_connected = false;
-
-static void process_stream_buffer(const char *buf, int len);
 void route_data(const char *src_if, const uint8_t *data, size_t len);
-static void tcp_client_task(void *arg);
-static void tcp_server_task(void *arg);
-static void udp_client_task(void *arg);
-static void udp_server_task(void *arg);
 
 void start_uart(void){
 	um1_uart_config_t uart1_cfg = global_uart_config[0];
@@ -124,107 +110,6 @@ void send_uart_packet_with_timestamp(int uart_port, const uint8_t *data, size_t 
                extended_buffer, total_len);
 }
 
-void init_stream_sockets(void) {
-    if (global_tcp_config.enabled) {
-        if (strcmp(global_tcp_config.role, "server") == 0) {
-            tcp_listen_sock = socket(AF_INET, SOCK_STREAM, 0);
-            if (tcp_listen_sock >= 0) {
-                struct sockaddr_in addr = {
-                    .sin_family = AF_INET,
-                    .sin_port = htons(global_tcp_config.port),
-                    .sin_addr.s_addr = htonl(INADDR_ANY)
-                };
-                if (bind(tcp_listen_sock, (struct sockaddr *)&addr, sizeof(addr)) == 0 &&
-                    listen(tcp_listen_sock, 1) == 0) {
-                    xTaskCreate(tcp_server_task, "tcp_server_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
-                } else {
-                    close(tcp_listen_sock);
-                    tcp_listen_sock = -1;
-                }
-            }
-        } else {
-            tcp_sock = socket(AF_INET, SOCK_STREAM, 0);
-            if (tcp_sock >= 0) {
-                tcp_dest.sin_family = AF_INET;
-                tcp_dest.sin_port = htons(global_tcp_config.port);
-                inet_pton(AF_INET, global_tcp_config.server, &tcp_dest.sin_addr);
-                if (connect(tcp_sock, (struct sockaddr *)&tcp_dest, sizeof(tcp_dest)) == 0) {
-                    tcp_connected = true;
-                    xTaskCreate(tcp_client_task, "tcp_client_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
-                } else {
-                    close(tcp_sock);
-                    tcp_sock = -1;
-                }
-            }
-        }
-    }
-
-    if (global_udp_config.enabled) {
-        udp_sock = socket(AF_INET, SOCK_DGRAM, 0);
-        if (udp_sock >= 0) {
-            if (strcmp(global_udp_config.role, "server") == 0) {
-                struct sockaddr_in addr = {
-                    .sin_family = AF_INET,
-                    .sin_port = htons(global_udp_config.port),
-                    .sin_addr.s_addr = htonl(INADDR_ANY)
-                };
-                if (bind(udp_sock, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
-                    udp_connected = true;
-                    xTaskCreate(udp_server_task, "udp_server_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
-                } else {
-                    close(udp_sock);
-                    udp_sock = -1;
-                }
-            } else {
-                udp_dest.sin_family = AF_INET;
-                udp_dest.sin_port = htons(global_udp_config.port);
-                inet_pton(AF_INET, global_udp_config.server, &udp_dest.sin_addr);
-                if (connect(udp_sock, (struct sockaddr *)&udp_dest, sizeof(udp_dest)) == 0) {
-                    udp_connected = true;
-                    xTaskCreate(udp_client_task, "udp_client_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
-                } else {
-                    close(udp_sock);
-                    udp_sock = -1;
-                }
-            }
-        }
-    }
-}
-
-void send_tcp_packet(int uart_port, const uint8_t *data, size_t len) {
-    if (!tcp_connected) return;
-
-    char buffer[BUF_SIZE + 16];
-    int offset = 0;
-    if (uart_port >= 0) {
-        offset = snprintf(buffer, sizeof(buffer), "uart%d:", uart_port);
-    }
-    if (offset + len > sizeof(buffer)) len = sizeof(buffer) - offset;
-    memcpy(buffer + offset, data, len);
-    if (send(tcp_sock, buffer, offset + len, 0) < 0) {
-        close(tcp_sock);
-        tcp_sock = -1;
-        tcp_connected = false;
-    }
-}
-
-void send_udp_packet(int uart_port, const uint8_t *data, size_t len) {
-    if (!udp_connected) return;
-
-    char buffer[BUF_SIZE + 16];
-    int offset = 0;
-    if (uart_port >= 0) {
-        offset = snprintf(buffer, sizeof(buffer), "uart%d:", uart_port);
-    }
-    if (offset + len > sizeof(buffer)) len = sizeof(buffer) - offset;
-    memcpy(buffer + offset, data, len);
-    if (send(udp_sock, buffer, offset + len, 0) < 0) {
-        close(udp_sock);
-        udp_sock = -1;
-        udp_connected = false;
-    }
-}
-
 void route_data(const char *src_if, const uint8_t *data, size_t len) {
     int src_uart_port = -1;
     if (strcasecmp(src_if, "UART1") == 0) src_uart_port = UART_PORT_NUM_1;
@@ -264,84 +149,6 @@ void route_data(const char *src_if, const uint8_t *data, size_t len) {
             uart_write_bytes(dst_port, (const char *)data, len);
         }
     }
-}
-
-static void process_stream_buffer(const char *buf, int len) {
-    if (len <= 0) return;
-    if (strncmp(buf, "uart1:", 6) == 0) {
-        uart_write_bytes(UART_PORT_NUM_1, buf + 6, len - 6);
-    } else if (strncmp(buf, "uart2:", 6) == 0) {
-        uart_write_bytes(UART_PORT_NUM_2, buf + 6, len - 6);
-    }
-}
-
-static void tcp_client_task(void *arg) {
-    char buffer[BUF_SIZE];
-    while (1) {
-        int len = recv(tcp_sock, buffer, sizeof(buffer), 0);
-        if (len <= 0) break;
-        route_data("LAN", (uint8_t *)buffer, len);
-        route_data("AP", (uint8_t *)buffer, len);
-        process_stream_buffer(buffer, len);
-    }
-    close(tcp_sock);
-    tcp_sock = -1;
-    tcp_connected = false;
-    vTaskDelete(NULL);
-}
-
-static void tcp_server_task(void *arg) {
-    char buffer[BUF_SIZE];
-    while (1) {
-        int client = accept(tcp_listen_sock, NULL, NULL);
-        if (client < 0) continue;
-        tcp_sock = client;
-        tcp_connected = true;
-        while (1) {
-            int len = recv(client, buffer, sizeof(buffer), 0);
-            if (len <= 0) break;
-            route_data("LAN", (uint8_t *)buffer, len);
-            route_data("AP", (uint8_t *)buffer, len);
-            process_stream_buffer(buffer, len);
-        }
-        close(client);
-        tcp_sock = -1;
-        tcp_connected = false;
-    }
-}
-
-static void udp_client_task(void *arg) {
-    char buffer[BUF_SIZE];
-    while (1) {
-        int len = recv(udp_sock, buffer, sizeof(buffer), 0);
-        if (len <= 0) break;
-        route_data("LAN", (uint8_t *)buffer, len);
-        route_data("AP", (uint8_t *)buffer, len);
-        process_stream_buffer(buffer, len);
-    }
-    close(udp_sock);
-    udp_sock = -1;
-    udp_connected = false;
-    vTaskDelete(NULL);
-}
-
-static void udp_server_task(void *arg) {
-    char buffer[BUF_SIZE];
-    struct sockaddr_in src_addr;
-    socklen_t addrlen = sizeof(src_addr);
-    while (1) {
-        int len = recvfrom(udp_sock, buffer, sizeof(buffer), 0,
-                           (struct sockaddr *)&src_addr, &addrlen);
-        if (len < 0) break;
-        route_data("LAN", (uint8_t *)buffer, len);
-        route_data("AP", (uint8_t *)buffer, len);
-        process_stream_buffer(buffer, len);
-    }
-    close(udp_sock);
-    udp_sock = -1;
-    udp_connected = false;
-    vTaskDelete(NULL);
-}
 
 uint64_t reverse_bytes_u64(uint64_t value) {
     uint64_t result = 0;


### PR DESCRIPTION
## Summary
- move TCP/UDP socket state and tasks from UART to LAN component
- expose LAN socket helpers and connection flags via um1_lan.h
- adjust includes so modules use LAN networking APIs

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895db8af97c832981e5539674fdaf6f