### PR TITLE
feat: add wifi and lan socket tasks

### DIFF
--- a/firmware/components/um1_lan/include/um1_lan.h
+++ b/firmware/components/um1_lan/include/um1_lan.h
@@ -28,5 +28,8 @@ void send_udp_packet(int uart_port, const uint8_t *data, size_t len);
 
 extern bool tcp_connected;
 extern bool udp_connected;
+extern int tcp_sock;
+extern int udp_sock;
+extern int tcp_listen_sock;
 
 #endif // UM1_LAN_H

--- a/firmware/components/um1_lan/um1_lan.c
+++ b/firmware/components/um1_lan/um1_lan.c
@@ -20,19 +20,19 @@
 
 static const char *TAG = "eth_if_tasks";
 
-static int tcp_sock = -1;
-static int tcp_listen_sock = -1;
-static int udp_sock = -1;
-static struct sockaddr_in tcp_dest;
-static struct sockaddr_in udp_dest;
+int tcp_sock = -1;
+int tcp_listen_sock = -1;
+int udp_sock = -1;
+struct sockaddr_in tcp_dest;
+struct sockaddr_in udp_dest;
 bool tcp_connected = false;
 bool udp_connected = false;
 
 static void process_stream_buffer(const char *buf, int len);
-static void tcp_client_task(void *arg);
-static void tcp_server_task(void *arg);
-static void udp_client_task(void *arg);
-static void udp_server_task(void *arg);
+static void lan_tcp_client_task(void *arg);
+static void lan_tcp_server_task(void *arg);
+static void lan_udp_client_task(void *arg);
+static void lan_udp_server_task(void *arg);
 
 static void send_text(int sock, const char *fmt, ...) {
     char buf[256];
@@ -112,7 +112,7 @@ void init_stream_sockets(void) {
                 };
                 if (bind(tcp_listen_sock, (struct sockaddr *)&addr, sizeof(addr)) == 0 &&
                     listen(tcp_listen_sock, 1) == 0) {
-                    xTaskCreate(tcp_server_task, "tcp_server_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+                    xTaskCreate(lan_tcp_server_task, "tcp_server_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
                 } else {
                     close(tcp_listen_sock);
                     tcp_listen_sock = -1;
@@ -126,7 +126,7 @@ void init_stream_sockets(void) {
                 inet_pton(AF_INET, global_tcp_config.server, &tcp_dest.sin_addr);
                 if (connect(tcp_sock, (struct sockaddr *)&tcp_dest, sizeof(tcp_dest)) == 0) {
                     tcp_connected = true;
-                    xTaskCreate(tcp_client_task, "tcp_client_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+                    xTaskCreate(lan_tcp_client_task, "tcp_client_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
                 } else {
                     close(tcp_sock);
                     tcp_sock = -1;
@@ -146,7 +146,7 @@ void init_stream_sockets(void) {
                 };
                 if (bind(udp_sock, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
                     udp_connected = true;
-                    xTaskCreate(udp_server_task, "udp_server_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+                    xTaskCreate(lan_udp_server_task, "udp_server_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
                 } else {
                     close(udp_sock);
                     udp_sock = -1;
@@ -157,7 +157,7 @@ void init_stream_sockets(void) {
                 inet_pton(AF_INET, global_udp_config.server, &udp_dest.sin_addr);
                 if (connect(udp_sock, (struct sockaddr *)&udp_dest, sizeof(udp_dest)) == 0) {
                     udp_connected = true;
-                    xTaskCreate(udp_client_task, "udp_client_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+                    xTaskCreate(lan_udp_client_task, "udp_client_task", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
                 } else {
                     close(udp_sock);
                     udp_sock = -1;
@@ -201,7 +201,7 @@ void send_udp_packet(int uart_port, const uint8_t *data, size_t len) {
     }
 }
 
-static void tcp_client_task(void *arg) {
+static void lan_tcp_client_task(void *arg) {
     char buffer[BUF_SIZE];
     while (1) {
         int len = recv(tcp_sock, buffer, sizeof(buffer), 0);
@@ -216,7 +216,7 @@ static void tcp_client_task(void *arg) {
     vTaskDelete(NULL);
 }
 
-static void tcp_server_task(void *arg) {
+static void lan_tcp_server_task(void *arg) {
     char buffer[BUF_SIZE];
     while (1) {
         int client = accept(tcp_listen_sock, NULL, NULL);
@@ -236,7 +236,7 @@ static void tcp_server_task(void *arg) {
     }
 }
 
-static void udp_client_task(void *arg) {
+static void lan_udp_client_task(void *arg) {
     char buffer[BUF_SIZE];
     while (1) {
         int len = recv(udp_sock, buffer, sizeof(buffer), 0);
@@ -251,7 +251,7 @@ static void udp_client_task(void *arg) {
     vTaskDelete(NULL);
 }
 
-static void udp_server_task(void *arg) {
+static void lan_udp_server_task(void *arg) {
     char buffer[BUF_SIZE];
     struct sockaddr_in src_addr;
     socklen_t addrlen = sizeof(src_addr);

--- a/firmware/components/um1_mqtt/um1_mqtt.c
+++ b/firmware/components/um1_mqtt/um1_mqtt.c
@@ -1,5 +1,6 @@
 #include "um1_mqtt.h"
 #include "um1_uart.h"
+#include "um1_router.h"
 
 static const char *TAG = "um1_mqtt";
 esp_mqtt_client_handle_t global_mqtt_client = NULL;
@@ -41,6 +42,8 @@ void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_t event
             topic[len] = '\0';
 
             ESP_LOGI(TAG, "MQTT_EVENT_DATA topic=%s", topic);
+
+            route_data("MQTT", (const uint8_t *)event->data, event->data_len);
 
             int uart_port = 0;
             if (sscanf(topic, "uart/%d", &uart_port) == 1) {

--- a/firmware/components/um1_wifi/include/um1_wifi.h
+++ b/firmware/components/um1_wifi/include/um1_wifi.h
@@ -17,6 +17,11 @@
 
 #include "um1_config.h"
 
+extern int wifi_ap_tcp_server_sock;
+extern int wifi_ap_tcp_client_sock;
+extern int wifi_ap_udp_server_sock;
+extern int wifi_ap_udp_client_sock;
+
 void start_wifi(void);
 
 #endif // UM1_WIFI_H

--- a/firmware/components/um1_wifi/um1_wifi.c
+++ b/firmware/components/um1_wifi/um1_wifi.c
@@ -8,6 +8,11 @@
 static esp_netif_t *wifi_ap_netif = NULL;
 static esp_netif_t *wifi_sta_netif = NULL;
 
+int wifi_ap_tcp_server_sock = -1;
+int wifi_ap_tcp_client_sock = -1;
+int wifi_ap_udp_server_sock = -1;
+int wifi_ap_udp_client_sock = -1;
+
 /* ===== AP MODE: TCP Server ===== */
 static void wifi_ap_tcp_server_task(void *pvParameters)
 {
@@ -66,6 +71,112 @@ static void wifi_ap_tcp_server_task(void *pvParameters)
     }
 
     close(listen_sock);
+    vTaskDelete(NULL);
+}
+
+/* ===== AP MODE: TCP Client ===== */
+static void wifi_ap_tcp_client_task(void *pvParameters)
+{
+    struct sockaddr_in dest_addr = {0};
+    dest_addr.sin_family = AF_INET;
+    dest_addr.sin_port = htons(TCP_PORT);
+    dest_addr.sin_addr.s_addr = inet_addr(global_tcp_config.server);
+
+    wifi_ap_tcp_client_sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    if (wifi_ap_tcp_client_sock < 0) {
+        ESP_LOGE(TAG, "Unable to create socket: errno %d", errno);
+        vTaskDelete(NULL);
+        return;
+    }
+
+    if (connect(wifi_ap_tcp_client_sock, (struct sockaddr *)&dest_addr, sizeof(dest_addr)) != 0) {
+        ESP_LOGE(TAG, "Socket unable to connect: errno %d", errno);
+        close(wifi_ap_tcp_client_sock);
+        wifi_ap_tcp_client_sock = -1;
+        vTaskDelete(NULL);
+        return;
+    }
+
+    uint8_t rx_buffer[1024];
+    int len;
+    while ((len = recv(wifi_ap_tcp_client_sock, rx_buffer, sizeof(rx_buffer), 0)) > 0) {
+        route_data("AP", rx_buffer, len);
+    }
+    close(wifi_ap_tcp_client_sock);
+    wifi_ap_tcp_client_sock = -1;
+    vTaskDelete(NULL);
+}
+
+/* ===== AP MODE: UDP Server ===== */
+static void wifi_ap_udp_server_task(void *pvParameters)
+{
+    esp_netif_ip_info_t ip_info;
+    ESP_ERROR_CHECK(esp_netif_get_ip_info(wifi_ap_netif, &ip_info));
+
+    wifi_ap_udp_server_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+    if (wifi_ap_udp_server_sock < 0) {
+        ESP_LOGE(TAG, "Unable to create UDP socket: errno %d", errno);
+        vTaskDelete(NULL);
+        return;
+    }
+
+    struct sockaddr_in server_addr = {
+        .sin_family = AF_INET,
+        .sin_addr.s_addr = ip_info.ip.addr,
+        .sin_port = htons(TCP_PORT),
+    };
+
+    if (bind(wifi_ap_udp_server_sock, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+        ESP_LOGE(TAG, "UDP socket bind failed: errno %d", errno);
+        close(wifi_ap_udp_server_sock);
+        wifi_ap_udp_server_sock = -1;
+        vTaskDelete(NULL);
+        return;
+    }
+
+    uint8_t rx_buffer[1024];
+    struct sockaddr_in source_addr;
+    socklen_t socklen = sizeof(source_addr);
+    int len;
+    while ((len = recvfrom(wifi_ap_udp_server_sock, rx_buffer, sizeof(rx_buffer), 0,
+                           (struct sockaddr *)&source_addr, &socklen)) >= 0) {
+        route_data("AP", rx_buffer, len);
+    }
+    close(wifi_ap_udp_server_sock);
+    wifi_ap_udp_server_sock = -1;
+    vTaskDelete(NULL);
+}
+
+/* ===== AP MODE: UDP Client ===== */
+static void wifi_ap_udp_client_task(void *pvParameters)
+{
+    struct sockaddr_in dest_addr = {0};
+    dest_addr.sin_family = AF_INET;
+    dest_addr.sin_port = htons(TCP_PORT);
+    dest_addr.sin_addr.s_addr = inet_addr(global_udp_config.server);
+
+    wifi_ap_udp_client_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+    if (wifi_ap_udp_client_sock < 0) {
+        ESP_LOGE(TAG, "Unable to create UDP socket: errno %d", errno);
+        vTaskDelete(NULL);
+        return;
+    }
+
+    if (connect(wifi_ap_udp_client_sock, (struct sockaddr *)&dest_addr, sizeof(dest_addr)) != 0) {
+        ESP_LOGE(TAG, "UDP socket unable to connect: errno %d", errno);
+        close(wifi_ap_udp_client_sock);
+        wifi_ap_udp_client_sock = -1;
+        vTaskDelete(NULL);
+        return;
+    }
+
+    uint8_t rx_buffer[1024];
+    int len;
+    while ((len = recv(wifi_ap_udp_client_sock, rx_buffer, sizeof(rx_buffer), 0)) > 0) {
+        route_data("AP", rx_buffer, len);
+    }
+    close(wifi_ap_udp_client_sock);
+    wifi_ap_udp_client_sock = -1;
     vTaskDelete(NULL);
 }
 
@@ -142,6 +253,9 @@ static void wifi_event_handler_ap(void *arg, esp_event_base_t event_base, int32_
     } else if (event_id == WIFI_EVENT_AP_START) {
         ESP_LOGI(TAG, "AP started");
         xTaskCreate(wifi_ap_tcp_server_task, "tcp_ap", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+        xTaskCreate(wifi_ap_tcp_client_task, "tcp_ap_client", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+        xTaskCreate(wifi_ap_udp_server_task, "udp_ap_server", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
+        xTaskCreate(wifi_ap_udp_client_task, "udp_ap_client", 4096, NULL, tskIDLE_PRIORITY + 5, NULL);
     }
 }
 


### PR DESCRIPTION
## Summary
- add TCP/UDP client and server tasks for Wi-Fi AP mode
- expose LAN sockets globally and align task naming
- forward MQTT messages to router for cross-module routing

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install espressif-idf` *(fails: no matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_689ae4f56c5c8329a4673c05ff830ff4