### PR TITLE
Add indexed router and integrate incoming data paths

### DIFF
--- a/firmware/components/um1_lan/um1_lan.c
+++ b/firmware/components/um1_lan/um1_lan.c
@@ -122,11 +122,24 @@ static void handle_lan_tcp_client_task(void *pvParameters)
     int sock = *((int *)pvParameters);
     free(pvParameters);
 
+    struct sockaddr_in peer;
+    socklen_t plen = sizeof(peer);
+    getpeername(sock, (struct sockaddr *)&peer, &plen);
+    uint32_t ip = peer.sin_addr.s_addr;
+    uint16_t port = ntohs(peer.sin_port);
+
     uint8_t buf[CHUNK_SZ];
     while (1) {
         int r = recv(sock, buf, sizeof(buf), 0);
         if (r > 0) {
-            // route_data(/* route */, buf, r);
+            rx_meta_t m = {
+                .src_id = IF_LAN,
+                .proto = PROTO_TCP,
+                .ip = ip,
+                .port = port,
+                .topic = NULL
+            };
+            router_route(&m, buf, r);
             continue;
         }
         if (r == 0) {
@@ -267,7 +280,14 @@ void lan_udp_task(void *arg)
         s_udp_peer_set = true;
         unlock_socks();
 
-        // route_data(/* route */, buf, r);
+        rx_meta_t m = {
+            .src_id = IF_LAN,
+            .proto = PROTO_UDP,
+            .ip = from.sin_addr.s_addr,
+            .port = ntohs(from.sin_port),
+            .topic = NULL
+        };
+        router_route(&m, buf, r);
 
     }
 

--- a/firmware/components/um1_mqtt/um1_mqtt.c
+++ b/firmware/components/um1_mqtt/um1_mqtt.c
@@ -1,5 +1,6 @@
 #include "um1_mqtt.h"
 #include "um1_uart.h"
+#include "um1_router.h"
 
 static const char *TAG = "um1_mqtt";
 esp_mqtt_client_handle_t global_mqtt_client = NULL;
@@ -47,6 +48,15 @@ void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_t event
                 int port_num = (uart_port == 2) ? UART_PORT_NUM_2 : UART_PORT_NUM_1;
                 uart_write_bytes(port_num, event->data, event->data_len);
             }
+
+            rx_meta_t m = {
+                .src_id = IF_STA,
+                .proto = PROTO_MQTT,
+                .ip = 0,
+                .port = 0,
+                .topic = topic
+            };
+            router_route(&m, (const uint8_t*)event->data, event->data_len);
         }
         break;
     case MQTT_EVENT_ERROR:

--- a/firmware/components/um1_router/include/um1_router.h
+++ b/firmware/components/um1_router/include/um1_router.h
@@ -3,7 +3,99 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
 
-void route_data(/* route */, const uint8_t *data, size_t len);
+// --- enums for interfaces and protocols ---
+
+typedef enum { IF_UART1 = 1, IF_UART2 = 2, IF_LAN = 3, IF_AP = 4, IF_STA = 5 } iface_type_t;
+
+typedef enum { PROTO_NONE = 0, PROTO_TCP = 1, PROTO_UDP = 2, PROTO_MQTT = 3 } proto_t;
+
+typedef enum {
+    ROLE_NONE = 0,
+    ROLE_CLIENT = 1,
+    ROLE_SERVER = 2,
+    ROLE_PUBLISH = 3,
+    ROLE_SUBSCRIBE = 4
+} role_t;
+
+typedef enum { PARITY_NONE = 0, PARITY_EVEN = 1, PARITY_ODD = 2 } parity_t;
+typedef enum { AUTH_OPEN = 0, AUTH_WPA2 = 1 } auth_t;
+
+// --- interface configurations ---
+
+typedef struct {
+    uint32_t baudrate;
+    parity_t parity;
+    uint8_t  bits;
+} uart_cfg_t;
+
+typedef struct {
+    role_t   role;
+    proto_t  proto;
+    uint32_t ip;
+    uint16_t port;
+    const char *topic;
+} net_cfg_t;
+
+typedef struct { net_cfg_t net; } lan_cfg_t;
+
+typedef struct {
+    const char *ssid;
+    const char *password;
+    auth_t auth;
+    net_cfg_t net;
+} wifi_cfg_t;
+
+typedef struct {
+    iface_type_t type;
+    union {
+        uart_cfg_t uart1;
+        uart_cfg_t uart2;
+        lan_cfg_t  lan;
+        wifi_cfg_t ap;
+        wifi_cfg_t sta;
+    } u;
+} phy_iface_t;
+
+typedef struct {
+    uint16_t    id;
+    bool        enable;
+    phy_iface_t iface;
+} endpoint_t;
+
+typedef enum {
+    RMF_MATCH_PROTO = 1<<0,
+    RMF_MATCH_IP    = 1<<1,
+    RMF_MATCH_PORT  = 1<<2,
+    RMF_MATCH_TOPIC = 1<<3,
+} route_match_flags_t;
+
+typedef struct {
+    bool        active;
+    uint16_t    src_id;
+    uint16_t    dst_id;
+    uint32_t    match_flags;
+    proto_t     proto;
+    uint32_t    ip;
+    uint16_t    port;
+    const char *topic;
+} route_t;
+
+typedef struct {
+    endpoint_t *endpoints; size_t endpoints_cnt;
+    route_t    *routes;    size_t routes_cnt;
+} router_t;
+
+typedef struct {
+    uint16_t    src_id;
+    proto_t     proto;
+    uint32_t    ip;
+    uint16_t    port;
+    const char *topic;
+} rx_meta_t;
+
+void router_init_from_config(void);
+void router_route(const rx_meta_t *m, const uint8_t *data, size_t len);
 
 #endif // UM1_ROUTER_H

--- a/firmware/components/um1_router/um1_router.c
+++ b/firmware/components/um1_router/um1_router.c
@@ -2,9 +2,281 @@
 #include "um1_config.h"
 #include "um1_mqtt.h"
 #include "um1_lan.h"
+#include "um1_uart.h"
+
 #include <driver/uart.h>
-#include <strings.h>
+#include <arpa/inet.h>
+#include <stdlib.h>
+#include <string.h>
 
-void route_data(/* route */, const uint8_t *data, size_t len) {
+// ----------------- small vector -----------------
 
+typedef struct { uint16_t *v; size_t n, cap; } vec_u16;
+
+static inline void vec_push(vec_u16 *a, uint16_t x){
+    if(a->n == a->cap){ a->cap = a->cap? a->cap*2 : 4;
+        a->v = (uint16_t*)realloc(a->v, a->cap*sizeof(uint16_t)); }
+    a->v[a->n++] = x;
 }
+
+// ----------------- index structures -----------------
+
+typedef struct { uint16_t port; vec_u16 dsts; } port_bucket_t;
+
+typedef struct {
+    uint32_t ip;
+    port_bucket_t *ports; size_t ports_n;
+    vec_u16 any_port;
+} ip_node_t;
+
+typedef struct {
+    proto_t proto;
+    ip_node_t *ips; size_t ips_n;
+    vec_u16 any_ip;
+} proto_node_t;
+
+typedef struct {
+    char *topic;
+    vec_u16 dsts;
+} topic_node_t;
+
+typedef struct {
+    uint16_t src_id;
+    proto_node_t *protos; size_t protos_n;
+    vec_u16 any_proto;
+
+    topic_node_t *topics; size_t topics_n;
+    vec_u16 any_topic;
+} src_index_t;
+
+typedef struct {
+    src_index_t *srcs; size_t srcs_n;
+} router_index_t;
+
+// ----------------- globals -----------------
+
+static router_t        g_router = {0};
+static router_index_t  g_index  = {0};
+
+// ----------------- helpers -----------------
+
+static src_index_t* find_src(router_index_t *idx, uint16_t src_id, bool create){
+    for(size_t i=0;i<idx->srcs_n;i++)
+        if(idx->srcs[i].src_id == src_id) return &idx->srcs[i];
+    if(!create) return NULL;
+    idx->srcs = realloc(idx->srcs, (idx->srcs_n+1)*sizeof(src_index_t));
+    src_index_t *s = &idx->srcs[idx->srcs_n++];
+    memset(s, 0, sizeof(*s));
+    s->src_id = src_id;
+    return s;
+}
+
+static proto_node_t* find_proto(src_index_t *s, proto_t p, bool create){
+    for(size_t i=0;i<s->protos_n;i++)
+        if(s->protos[i].proto == p) return &s->protos[i];
+    if(!create) return NULL;
+    s->protos = realloc(s->protos, (s->protos_n+1)*sizeof(proto_node_t));
+    proto_node_t *pn = &s->protos[s->protos_n++];
+    memset(pn,0,sizeof(*pn));
+    pn->proto = p;
+    return pn;
+}
+
+static ip_node_t* find_ip(proto_node_t *pn, uint32_t ip, bool create){
+    for(size_t i=0;i<pn->ips_n;i++)
+        if(pn->ips[i].ip == ip) return &pn->ips[i];
+    if(!create) return NULL;
+    pn->ips = realloc(pn->ips, (pn->ips_n+1)*sizeof(ip_node_t));
+    ip_node_t *in = &pn->ips[pn->ips_n++];
+    memset(in,0,sizeof(*in));
+    in->ip = ip;
+    return in;
+}
+
+static port_bucket_t* find_port(ip_node_t *in, uint16_t port, bool create){
+    for(size_t i=0;i<in->ports_n;i++)
+        if(in->ports[i].port == port) return &in->ports[i];
+    if(!create) return NULL;
+    in->ports = realloc(in->ports, (in->ports_n+1)*sizeof(port_bucket_t));
+    port_bucket_t *pb = &in->ports[in->ports_n++];
+    memset(pb,0,sizeof(*pb));
+    pb->port = port;
+    return pb;
+}
+
+static topic_node_t* find_topic(src_index_t *s, const char *topic, bool create){
+    for(size_t i=0;i<s->topics_n;i++)
+        if(strcmp(s->topics[i].topic, topic)==0) return &s->topics[i];
+    if(!create) return NULL;
+    s->topics = realloc(s->topics, (s->topics_n+1)*sizeof(topic_node_t));
+    topic_node_t *tn = &s->topics[s->topics_n++];
+    memset(tn,0,sizeof(*tn));
+    tn->topic = strdup(topic);
+    return tn;
+}
+
+// ----------------- build index -----------------
+
+static void router_build_index(const router_t *r, router_index_t *idx){
+    memset(idx, 0, sizeof(*idx));
+    for(size_t i=0;i<r->routes_cnt;i++){
+        const route_t *rt = &r->routes[i];
+        if(!rt->active) continue;
+
+        src_index_t *s = find_src(idx, rt->src_id, true);
+
+        if((rt->match_flags & RMF_MATCH_PROTO) && rt->proto == PROTO_MQTT){
+            if(rt->match_flags & RMF_MATCH_TOPIC){
+                topic_node_t *tn = find_topic(s, rt->topic, true);
+                vec_push(&tn->dsts, rt->dst_id);
+            }else{
+                vec_push(&s->any_topic, rt->dst_id);
+            }
+            continue;
+        }
+
+        if(rt->match_flags & RMF_MATCH_PROTO){
+            proto_node_t *pn = find_proto(s, rt->proto, true);
+            if(rt->match_flags & RMF_MATCH_IP){
+                ip_node_t *in = find_ip(pn, rt->ip, true);
+                if(rt->match_flags & RMF_MATCH_PORT){
+                    port_bucket_t *pb = find_port(in, rt->port, true);
+                    vec_push(&pb->dsts, rt->dst_id);
+                }else{
+                    vec_push(&in->any_port, rt->dst_id);
+                }
+            }else{
+                vec_push(&pn->any_ip, rt->dst_id);
+            }
+        }else{
+            vec_push(&s->any_proto, rt->dst_id);
+        }
+    }
+}
+
+// ----------------- endpoint lookup -----------------
+
+static endpoint_t* router_find_ep(router_t *r, uint16_t id){
+    for(size_t i=0;i<r->endpoints_cnt;i++)
+        if(r->endpoints[i].id == id) return &r->endpoints[i];
+    return NULL;
+}
+
+static void send_to_endpoint(const endpoint_t *dst,
+                             const rx_meta_t *meta,
+                             const uint8_t *data, size_t len){
+    if(!dst || !dst->enable) return;
+    switch(dst->iface.type){
+    case IF_UART1:
+        uart_write_bytes(UART_PORT_NUM_1, (const char*)data, len);
+        break;
+    case IF_UART2:
+        uart_write_bytes(UART_PORT_NUM_2, (const char*)data, len);
+        break;
+    case IF_LAN:
+    case IF_AP:
+    case IF_STA:
+        if(meta->proto == PROTO_UDP) send_udp_packet(data, len);
+        else if(meta->proto == PROTO_MQTT) um1_mqtt_publish(data, len);
+        else send_tcp_packet(data, len);
+        break;
+    }
+}
+
+static void send_vec(router_t *r, const vec_u16 *v,
+                     const rx_meta_t *m, const uint8_t *data, size_t len){
+    for(size_t i=0;i<v->n;i++){
+        endpoint_t *dst = router_find_ep(r, v->v[i]);
+        if(dst) send_to_endpoint(dst, m, data, len);
+    }
+}
+
+static void route_data_fast(router_t *r, const router_index_t *idx,
+                            const rx_meta_t *m, const uint8_t *data, size_t len){
+    const src_index_t *s = NULL;
+    for(size_t i=0;i<idx->srcs_n;i++) if(idx->srcs[i].src_id==m->src_id){ s=&idx->srcs[i]; break; }
+    if(!s) return;
+
+    if(m->proto == PROTO_MQTT){
+        for(size_t i=0;i<s->topics_n;i++)
+            if(strcmp(s->topics[i].topic, m->topic?m->topic:"")==0){
+                send_vec(r, &s->topics[i].dsts, m, data, len);
+                break;
+            }
+        send_vec(r, &s->any_topic, m, data, len);
+        return;
+    }
+
+    const proto_node_t *pn = NULL;
+    for(size_t i=0;i<s->protos_n;i++) if(s->protos[i].proto==m->proto){ pn=&s->protos[i]; break; }
+
+    if(pn){
+        for(size_t i=0;i<pn->ips_n;i++) if(pn->ips[i].ip==m->ip){
+            const ip_node_t *in = &pn->ips[i];
+            for(size_t j=0;j<in->ports_n;j++) if(in->ports[j].port==m->port){
+                send_vec(r, &in->ports[j].dsts, m, data, len);
+                break;
+            }
+            send_vec(r, &in->any_port, m, data, len);
+            goto done_proto;
+        }
+        send_vec(r, &pn->any_ip, m, data, len);
+    }
+done_proto:
+    send_vec(r, &s->any_proto, m, data, len);
+}
+
+// ----------------- configuration conversion -----------------
+
+static iface_type_t iface_from_str(const char *s){
+    if(!s) return 0;
+    if(strcasecmp(s,"UART1")==0) return IF_UART1;
+    if(strcasecmp(s,"UART2")==0) return IF_UART2;
+    if(strcasecmp(s,"LAN")==0)   return IF_LAN;
+    if(strcasecmp(s,"AP")==0)    return IF_AP;
+    if(strcasecmp(s,"STA")==0)   return IF_STA;
+    return 0;
+}
+
+static proto_t proto_from_str(const char *s){
+    if(!s) return PROTO_NONE;
+    if(strcasecmp(s,"TCP")==0) return PROTO_TCP;
+    if(strcasecmp(s,"UDP")==0) return PROTO_UDP;
+    if(strcasecmp(s,"MQTT")==0) return PROTO_MQTT;
+    return PROTO_NONE;
+}
+
+void router_init_from_config(void){
+    static endpoint_t eps[5];
+    eps[0] = (endpoint_t){ .id=IF_UART1, .enable=true, .iface={.type=IF_UART1} };
+    eps[1] = (endpoint_t){ .id=IF_UART2, .enable=true, .iface={.type=IF_UART2} };
+    eps[2] = (endpoint_t){ .id=IF_LAN,   .enable=true, .iface={.type=IF_LAN} };
+    eps[3] = (endpoint_t){ .id=IF_AP,    .enable=true, .iface={.type=IF_AP} };
+    eps[4] = (endpoint_t){ .id=IF_STA,   .enable=true, .iface={.type=IF_STA} };
+
+    g_router.endpoints = eps;
+    g_router.endpoints_cnt = 5;
+
+    static route_t routes[MAX_ROUTES];
+    for(int i=0;i<global_route_count && i<MAX_ROUTES;i++){
+        route_config_t *rc = &global_routes[i];
+        route_t *rt = &routes[i];
+        memset(rt,0,sizeof(*rt));
+        rt->active = rc->active;
+        rt->src_id = iface_from_str(rc->src.interface);
+        rt->dst_id = iface_from_str(rc->dst.interface);
+        if(rc->src.protocol[0]){ rt->match_flags |= RMF_MATCH_PROTO; rt->proto = proto_from_str(rc->src.protocol); }
+        if(rc->src.ip[0]){ rt->match_flags |= RMF_MATCH_IP; rt->ip = inet_addr(rc->src.ip); }
+        if(rc->src.port){ rt->match_flags |= RMF_MATCH_PORT; rt->port = (uint16_t)rc->src.port; }
+        if(rc->src.topic[0]){ rt->match_flags |= RMF_MATCH_TOPIC; rt->topic = strdup(rc->src.topic); }
+    }
+    g_router.routes = routes;
+    g_router.routes_cnt = global_route_count < MAX_ROUTES ? global_route_count : MAX_ROUTES;
+
+    router_build_index(&g_router, &g_index);
+}
+
+void router_route(const rx_meta_t *m, const uint8_t *data, size_t len){
+    route_data_fast(&g_router, &g_index, m, data, len);
+}
+

--- a/firmware/components/um1_uart/um1_uart.c
+++ b/firmware/components/um1_uart/um1_uart.c
@@ -104,9 +104,14 @@ void send_uart_packet_with_timestamp(int uart_port, const uint8_t *data, size_t 
     // WebSocket
     send_uart_ws_data(uart_port, extended_buffer, total_len);
 
-    // Route to other interfaces according to routing table
-    route_data(uart_port == UART_PORT_NUM_1 ? "UART1" : "UART2",
-               extended_buffer, total_len);
+    rx_meta_t m = {
+        .src_id = (uart_port == UART_PORT_NUM_1) ? IF_UART1 : IF_UART2,
+        .proto = PROTO_NONE,
+        .ip = 0,
+        .port = 0,
+        .topic = NULL
+    };
+    router_route(&m, extended_buffer, total_len);
 }
 
 

--- a/firmware/components/um1_wifi/um1_wifi.c
+++ b/firmware/components/um1_wifi/um1_wifi.c
@@ -57,10 +57,19 @@ static void wifi_ap_tcp_server_task(void *pvParameters)
         ESP_LOGI(TAG, "AP client from %s:%d",
                  inet_ntoa(client_addr.sin_addr), ntohs(client_addr.sin_port));
 
+        uint32_t ip = client_addr.sin_addr.s_addr;
+        uint16_t port = ntohs(client_addr.sin_port);
         uint8_t rx_buffer[1024];
         int len;
         while ((len = recv(client_sock, rx_buffer, sizeof(rx_buffer), 0)) > 0) {
-            route_data(/*route*/, rx_buffer, len);
+            rx_meta_t m = {
+                .src_id = IF_AP,
+                .proto = PROTO_TCP,
+                .ip = ip,
+                .port = port,
+                .topic = NULL
+            };
+            router_route(&m, rx_buffer, len);
         }
         close(client_sock);
     }
@@ -118,10 +127,19 @@ static void wifi_sta_tcp_server_task(void *pvParameters)
         ESP_LOGI(TAG, "STA client from %s:%d",
                  inet_ntoa(client_addr.sin_addr), ntohs(client_addr.sin_port));
 
+        uint32_t ip = client_addr.sin_addr.s_addr;
+        uint16_t port = ntohs(client_addr.sin_port);
         uint8_t rx_buffer[1024];
         int len;
         while ((len = recv(client_sock, rx_buffer, sizeof(rx_buffer), 0)) > 0) {
-            route_data(/* route */, rx_buffer, len);
+            rx_meta_t m = {
+                .src_id = IF_STA,
+                .proto = PROTO_TCP,
+                .ip = ip,
+                .port = port,
+                .topic = NULL
+            };
+            router_route(&m, rx_buffer, len);
         }
         close(client_sock);
     }

--- a/firmware/main/main.c
+++ b/firmware/main/main.c
@@ -26,6 +26,7 @@
 #include "um1_config.h"
 #include "um1_mqtt.h"
 #include "um1_sntp.h"
+#include "um1_router.h"
 
 void init_esp_environment(void)
 {
@@ -46,7 +47,8 @@ void app_main(void)
 
     start_spiffs();
     vTaskDelay(pdMS_TO_TICKS(1000));
-	read_config_and_apply();
+        read_config_and_apply();
+        router_init_from_config();
 
 	start_wifi();
 	vTaskDelay(pdMS_TO_TICKS(1000));
@@ -57,10 +59,10 @@ void app_main(void)
 	start_webserver();
 	vTaskDelay(pdMS_TO_TICKS(1000));
 
-	start_uart();
-	vTaskDelay(pdMS_TO_TICKS(1000));
+        start_uart();
+        vTaskDelay(pdMS_TO_TICKS(1000));
 
-	start_mqtt();
+        start_mqtt();
 	vTaskDelay(pdMS_TO_TICKS(1000));
 
 	start_sntp();


### PR DESCRIPTION
## Summary
- implement full routing infrastructure with enums, endpoint structs and indexed rule lookup
- convert configuration routes into router index and deliver data to destination interfaces
- route incoming data from LAN, WiFi, UART and MQTT modules using new router
- initialize router during system startup

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b43cb1cac83298aec0d3d5a027670