### PR TITLE
Expose LAN stream connection status

### DIFF
--- a/firmware/components/um1_http_server/um1_http_server.c
+++ b/firmware/components/um1_http_server/um1_http_server.c
@@ -185,8 +185,8 @@ esp_err_t system_info_handler(httpd_req_t *req)
 esp_err_t stream_status_handler(httpd_req_t *req)
 {
     cJSON *root = cJSON_CreateObject();
-    cJSON_AddBoolToObject(root, "tcp", tcp_connected);
-    cJSON_AddBoolToObject(root, "udp", udp_connected);
+    cJSON_AddBoolToObject(root, "tcp", lan_tcp_connected());
+    cJSON_AddBoolToObject(root, "udp", lan_udp_connected());
     char *out = cJSON_PrintUnformatted(root);
     httpd_resp_set_type(req, "application/json");
     httpd_resp_sendstr(req, out);

--- a/firmware/components/um1_lan/include/um1_lan.h
+++ b/firmware/components/um1_lan/include/um1_lan.h
@@ -22,6 +22,8 @@
 
 void send_tcp_packet(const uint8_t *data, size_t len);
 void send_udp_packet(const uint8_t *data, size_t len);
+bool lan_tcp_connected(void);
+bool lan_udp_connected(void);
 
 void lan_tcp_task(void *arg);
 void lan_udp_task(void *arg);

--- a/firmware/components/um1_lan/um1_lan.c
+++ b/firmware/components/um1_lan/um1_lan.c
@@ -115,6 +115,28 @@ void send_udp_packet(const uint8_t *data, size_t len)
     }
 }
 
+bool lan_tcp_connected(void)
+{
+    bool connected = false;
+    lock_socks();
+    for (int i = 0; i < MAX_TCP_CLIENTS; ++i) {
+        if (s_tcp_clients[i] != -1) {
+            connected = true;
+            break;
+        }
+    }
+    unlock_socks();
+    return connected;
+}
+
+bool lan_udp_connected(void)
+{
+    lock_socks();
+    bool connected = (s_udp_sock != -1) && s_udp_peer_set;
+    unlock_socks();
+    return connected;
+}
+
 /* ------- TCP data server ------- */
 
 static void handle_lan_tcp_client_task(void *pvParameters)


### PR DESCRIPTION
## Summary
- add helpers to check TCP/UDP socket connectivity
- show LAN connection state in HTTP stream status handler

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b482798348329a0e410340bad78fc