### PR TITLE
Fix diagnostics section 404 by resolving directory URLs

### DIFF
--- a/firmware/components/um1_http_server/um1_http_server.c
+++ b/firmware/components/um1_http_server/um1_http_server.c
@@ -457,6 +457,13 @@ esp_err_t spiffs_get_handler(httpd_req_t *req)
         strlcat(path, "index.html", sizeof(path));
     } else {
         strlcat(path, req->uri, sizeof(path));
+        if (!strchr(req->uri, '.')) {
+            const char *basename = strrchr(req->uri, '/');
+            basename = basename ? basename + 1 : req->uri;
+            strlcat(path, "/", sizeof(path));
+            strlcat(path, basename, sizeof(path));
+            strlcat(path, ".html", sizeof(path));
+        }
     }
 
     if (!is_public_uri(req->uri) && !token_is_valid(req)) {


### PR DESCRIPTION
## Summary
- ensure requests without extensions resolve to matching HTML file

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d8962407883298c088d8876f33797