### PR TITLE
Add IP and MQTT profile sections to settings

### DIFF
--- a/web/src/config.json
+++ b/web/src/config.json
@@ -66,5 +66,29 @@
     "enabled": true,
     "server_ip": "pool.ntp.org",
     "sync_interval_sec": 3600
+  },
+  "ip_profile": {
+    "ip1": {
+      "client": true,
+      "address": "192.168.0.10",
+      "port": 1234,
+      "transport": "TCP"
+    },
+    "ip2": {
+      "client": false,
+      "address": "192.168.0.20",
+      "port": 5678,
+      "transport": "UDP"
+    }
+  },
+  "mqtt_profile": {
+    "mqtt1": {
+      "tx_topic": "uart/tx1",
+      "rx_topic": "uart/rx1"
+    },
+    "mqtt2": {
+      "tx_topic": "uart/tx2",
+      "rx_topic": "uart/rx2"
+    }
   }
 }

--- a/web/src/settings/settings.html
+++ b/web/src/settings/settings.html
@@ -124,6 +124,36 @@
       </div>
       <button id="change_creds_btn">Изменить</button>
     </div>
+    <div class="card">
+      <h3>IP профиль</h3>
+      <h4>Подключение по IP 1 (IP_1):</h4>
+      <table class="settings-table">
+        <tr><td>Клиент:</td><td><input type="checkbox" id="ip1_client" /></td></tr>
+        <tr><td>Адрес IP:</td><td><input type="text" id="ip1_address" /></td></tr>
+        <tr><td>Порт:</td><td><input type="number" id="ip1_port" /></td></tr>
+        <tr><td>Транспортный протокол:</td><td><select id="ip1_transport"><option value="TCP">TCP</option><option value="UDP">UDP</option></select></td></tr>
+      </table>
+      <h4>Подключение по IP 2 (IP_2):</h4>
+      <table class="settings-table">
+        <tr><td>Клиент:</td><td><input type="checkbox" id="ip2_client" /></td></tr>
+        <tr><td>Адрес IP:</td><td><input type="text" id="ip2_address" /></td></tr>
+        <tr><td>Порт:</td><td><input type="number" id="ip2_port" /></td></tr>
+        <tr><td>Транспортный протокол:</td><td><select id="ip2_transport"><option value="TCP">TCP</option><option value="UDP">UDP</option></select></td></tr>
+      </table>
+    </div>
+    <div class="card">
+      <h3>MQTT профиль</h3>
+      <h4>Подключение к MQTT топику 1 (MQTT_1):</h4>
+      <table class="settings-table">
+        <tr><td>Топик для отправки данных (публикация):</td><td><input type="text" id="mqtt1_pub_topic" /></td></tr>
+        <tr><td>Топик для приема данных (подписка):</td><td><input type="text" id="mqtt1_sub_topic" /></td></tr>
+      </table>
+      <h4>Подключение к MQTT топику 2 (MQTT_2):</h4>
+      <table class="settings-table">
+        <tr><td>Топик для отправки данных (публикация):</td><td><input type="text" id="mqtt2_pub_topic" /></td></tr>
+        <tr><td>Топик для приема данных (подписка):</td><td><input type="text" id="mqtt2_sub_topic" /></td></tr>
+      </table>
+    </div>
     <button onclick="collectSettings()">Сохранить настройки</button>
     <pre id="json_output"></pre>
   </div>

--- a/web/src/settings/settings.js
+++ b/web/src/settings/settings.js
@@ -87,7 +87,31 @@ function collectSettings(){
     mqtt:{ enabled:document.getElementById('mqtt_enabled').checked, broker:document.getElementById('mqtt_broker').value, username:document.getElementById('mqtt_username').value, password:document.getElementById('mqtt_password').value },
     tcp:{ enabled:document.getElementById('tcp_enabled').checked, server:document.getElementById('tcp_server').value, port:+document.getElementById('tcp_port').value },
     udp:{ enabled:document.getElementById('udp_enabled').checked, server:document.getElementById('udp_server').value, port:+document.getElementById('udp_port').value },
-    sntp:{ enabled:document.getElementById('sntp_enabled').checked, server_ip:document.getElementById('sntp_server_ip').value, sync_interval_sec:+document.getElementById('sntp_interval').value }
+    sntp:{ enabled:document.getElementById('sntp_enabled').checked, server_ip:document.getElementById('sntp_server_ip').value, sync_interval_sec:+document.getElementById('sntp_interval').value },
+    ip_profile:{
+      ip1:{
+        client:document.getElementById('ip1_client').checked,
+        address:document.getElementById('ip1_address').value,
+        port:+document.getElementById('ip1_port').value,
+        transport:document.getElementById('ip1_transport').value
+      },
+      ip2:{
+        client:document.getElementById('ip2_client').checked,
+        address:document.getElementById('ip2_address').value,
+        port:+document.getElementById('ip2_port').value,
+        transport:document.getElementById('ip2_transport').value
+      }
+    },
+    mqtt_profile:{
+      mqtt1:{
+        tx_topic:document.getElementById('mqtt1_pub_topic').value,
+        rx_topic:document.getElementById('mqtt1_sub_topic').value
+      },
+      mqtt2:{
+        tx_topic:document.getElementById('mqtt2_pub_topic').value,
+        rx_topic:document.getElementById('mqtt2_sub_topic').value
+      }
+    }
   };
   fetch('/config', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(settings)})
     .then(r=>{ if(r.ok) showNotification('✅ Настройки успешно сохранены'); else showNotification('❌ Ошибка сохранения',true); })
@@ -137,6 +161,19 @@ async function loadConfigFromServer(){
     document.getElementById('sntp_enabled').checked=config.sntp.enabled;
     document.getElementById('sntp_server_ip').value=config.sntp.server_ip;
     document.getElementById('sntp_interval').value=config.sntp.sync_interval_sec;
+
+    document.getElementById('ip1_client').checked=config.ip_profile.ip1.client;
+    document.getElementById('ip1_address').value=config.ip_profile.ip1.address;
+    document.getElementById('ip1_port').value=config.ip_profile.ip1.port;
+    document.getElementById('ip1_transport').value=config.ip_profile.ip1.transport;
+    document.getElementById('ip2_client').checked=config.ip_profile.ip2.client;
+    document.getElementById('ip2_address').value=config.ip_profile.ip2.address;
+    document.getElementById('ip2_port').value=config.ip_profile.ip2.port;
+    document.getElementById('ip2_transport').value=config.ip_profile.ip2.transport;
+    document.getElementById('mqtt1_pub_topic').value=config.mqtt_profile.mqtt1.tx_topic;
+    document.getElementById('mqtt1_sub_topic').value=config.mqtt_profile.mqtt1.rx_topic;
+    document.getElementById('mqtt2_pub_topic').value=config.mqtt_profile.mqtt2.tx_topic;
+    document.getElementById('mqtt2_sub_topic').value=config.mqtt_profile.mqtt2.rx_topic;
 
     toggleLanFields();
     toggleWifiFields();


### PR DESCRIPTION
## Summary
- add IP profile section for two IP connections
- add MQTT profile section with topic fields

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689da56c6cb08329bbf1b3ecf75937cd