### PR TITLE
Darken disabled form elements

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -74,10 +74,21 @@ select {
   background: #2b2b2b;
   color: var(--text);
 }
+input:disabled,
+select:disabled,
+textarea:disabled {
+  background: #1a1a1a;
+  color: var(--text-muted);
+}
 button {
   background: var(--accent);
   color: #000;
   cursor: pointer;
+}
+button:disabled {
+  background: #3a3a3a;
+  color: var(--text-muted);
+  cursor: not-allowed;
 }
 button.secondary {
   background: transparent;


### PR DESCRIPTION
## Summary
- improve accessibility by darkening backgrounds of disabled inputs and buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dc1a032d4832980b3a3f053ae6137