### PR TITLE
Darken disabled fields

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -77,7 +77,7 @@ select {
 input:disabled,
 select:disabled,
 textarea:disabled {
-  background: #1a1a1a;
+  background: #0d0d0d;
   color: var(--text-muted);
 }
 button {
@@ -86,7 +86,7 @@ button {
   cursor: pointer;
 }
 button:disabled {
-  background: #3a3a3a;
+  background: #2a2a2a;
   color: var(--text-muted);
   cursor: not-allowed;
 }


### PR DESCRIPTION
## Summary
- darken disabled form field backgrounds for better contrast

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dc2c8b3388329a91befe7af94915f