### PR TITLE
Improve disabled text contrast

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -4,7 +4,7 @@
   --accent: #4fc3f7;
   --text: #e0e0e0;
   --text-muted: #b0b0b0;
-  --text-disabled: #111111;
+  --text-disabled: #4a4a4a;
   --radius: 8px;
   --gap: 16px;
   --font: system-ui, -apple-system, sans-serif;


### PR DESCRIPTION
## Summary
- use dark gray text for disabled form fields to improve visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dc55070d48329b52d6abd0a1d4bb4