### PR TITLE
Add dynamic routing infographic to gateway page

### DIFF
--- a/web/src/gateway/gateway.html
+++ b/web/src/gateway/gateway.html
@@ -100,6 +100,7 @@
           </td>
         </tr>
       </table>
+      <pre id="route_info" class="infographic"></pre>
     </div>
   </div>
   <script src="/app.js"></script>

--- a/web/src/gateway/gateway.js
+++ b/web/src/gateway/gateway.js
@@ -6,6 +6,50 @@ document.addEventListener('DOMContentLoaded', () => {
     { intf: 'mon_uart2_intf', profile: 'mon_uart2_profile' },
   ];
 
+  let cfg = null;
+
+  function fmtUart(key) {
+    const u = cfg[key];
+    return `${key.toUpperCase()} [${u.baudrate}][${u.parity}][${u.stop_bits}]`;
+  }
+
+  function fmtIp(intf, profile) {
+    const p = cfg.ip_profile[profile];
+    const ip = intf === 'lan' ? cfg.lan.static_ip : intf === 'ap' ? cfg.wifi.ap.static_ip : cfg.wifi.sta.static_ip;
+    const role = p.client ? 'Client' : 'Server';
+    return `${intf.toUpperCase()} [${ip}][${role}][${p.address}][${p.port}][${p.transport}]`;
+  }
+
+  function fmtMqtt(intf, profile) {
+    const p = cfg.mqtt_profile[profile];
+    return `${intf.toUpperCase()} [MQTT][${p.tx_topic}][${p.rx_topic}]`;
+  }
+
+  function fmtIntf(intf, profile) {
+    if (intf === 'uart1' || intf === 'uart2') return fmtUart(intf);
+    if (!profile) return intf.toUpperCase();
+    if (profile.startsWith('ip')) return fmtIp(intf, profile);
+    if (profile.startsWith('mqtt')) return fmtMqtt(intf, profile);
+    return intf.toUpperCase();
+  }
+
+  function render() {
+    if (!cfg) return;
+    const gw1 = document.getElementById('gw_uart1_intf').value;
+    const gw1p = document.getElementById('gw_uart1_profile').value;
+    const mon1 = document.getElementById('mon_uart1_intf').value;
+    const mon1p = document.getElementById('mon_uart1_profile').value;
+    const gw2 = document.getElementById('gw_uart2_intf').value;
+    const gw2p = document.getElementById('gw_uart2_profile').value;
+    const mon2 = document.getElementById('mon_uart2_intf').value;
+    const mon2p = document.getElementById('mon_uart2_profile').value;
+
+    const line1 = `${fmtUart('uart1')} <-> ${fmtIntf(gw1, gw1 === 'uart2' ? null : gw1p)} (Шлюз) дублируются на ${fmtIntf(mon1, mon1 === 'uart1' || mon1 === 'uart2' ? null : mon1p)} (Монитор)`;
+    const line2 = `${fmtUart('uart2')} <-> ${fmtIntf(gw2, gw2 === 'uart1' ? null : gw2p)} (Шлюз) дублируются на ${fmtIntf(mon2, mon2 === 'uart1' || mon2 === 'uart2' ? null : mon2p)} (Монитор)`;
+
+    document.getElementById('route_info').textContent = `${line1}\n${line2}`;
+  }
+
   toggles.forEach(({ intf, profile }) => {
     const intfSelect = document.getElementById(intf);
     const profileSelect = document.getElementById(profile);
@@ -13,9 +57,16 @@ document.addEventListener('DOMContentLoaded', () => {
     function update() {
       const value = intfSelect.value;
       profileSelect.disabled = value === 'uart1' || value === 'uart2';
+      render();
     }
 
     intfSelect.addEventListener('change', update);
+    profileSelect.addEventListener('change', render);
     update();
   });
+
+  fetch('/config.json')
+    .then(r => r.json())
+    .then(data => { cfg = data; render(); })
+    .catch(() => {});
 });

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -170,3 +170,11 @@ body.fullscreen-center {
 }
 
 .status-dot.on { background:#2e7d32; }
+
+.infographic {
+  margin-top: 1rem;
+  background: #2b2b2b;
+  padding: 8px;
+  border-radius: var(--radius);
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
## Summary
- show routing/monitoring infographic after gateway settings table
- compute infographic dynamically from current interface selections and profiles
- style infographic display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dd29981e88329bb9e695e94d2e34f