### PR TITLE
Add route saving and reboot control

### DIFF
--- a/firmware/components/um1_config/include/um1_config.h
+++ b/firmware/components/um1_config/include/um1_config.h
@@ -59,6 +59,28 @@ typedef struct {
     int sync_interval_sec;
 } sntp_config_t;
 
+typedef struct {
+    bool client;
+    char address[64];
+    int port;
+    char transport[8];
+} ip_profile_t;
+
+typedef struct {
+    char tx_topic[64];
+    char rx_topic[64];
+} mqtt_profile_t;
+
+typedef struct {
+    char intf[8];
+    char profile[8];
+} route_item_t;
+
+typedef struct {
+    route_item_t gateway[2];
+    route_item_t monitor[2];
+} routing_config_t;
+
 extern lan_config_t global_lan_config;
 extern um1_wifi_config_t global_wifi_config;
 extern um1_uart_config_t global_uart_config[2];
@@ -66,6 +88,9 @@ extern mqtt_config_t global_mqtt_config;
 extern stream_config_t global_tcp_config;
 extern stream_config_t global_udp_config;
 extern sntp_config_t global_sntp_config;
+extern ip_profile_t global_ip_profiles[2];
+extern mqtt_profile_t global_mqtt_profiles[2];
+extern routing_config_t global_routing_config;
 
 void read_config_and_apply(void);
 

--- a/firmware/components/um1_config/um1_config.c
+++ b/firmware/components/um1_config/um1_config.c
@@ -8,6 +8,9 @@ mqtt_config_t global_mqtt_config;
 stream_config_t global_tcp_config;
 stream_config_t global_udp_config;
 sntp_config_t global_sntp_config;
+ip_profile_t global_ip_profiles[2];
+mqtt_profile_t global_mqtt_profiles[2];
+routing_config_t global_routing_config;
 
 void read_config_and_apply(void)
 {
@@ -150,17 +153,83 @@ void read_config_and_apply(void)
                 strcpy(global_udp_config.role, "client");
             }
         }
-	cJSON *sntp = cJSON_GetObjectItem(root, "sntp");
-	if (sntp) {
-	    global_sntp_config.enabled = cJSON_GetObjectItem(sntp, "enabled")->valueint;
-	    strcpy(global_sntp_config.server_ip, cJSON_GetObjectItem(sntp, "server_ip")->valuestring);
-	    global_sntp_config.sync_interval_sec = cJSON_GetObjectItem(sntp, "sync_interval_sec")->valueint;
+        cJSON *sntp = cJSON_GetObjectItem(root, "sntp");
+        if (sntp) {
+            global_sntp_config.enabled = cJSON_GetObjectItem(sntp, "enabled")->valueint;
+            strcpy(global_sntp_config.server_ip, cJSON_GetObjectItem(sntp, "server_ip")->valuestring);
+            global_sntp_config.sync_interval_sec = cJSON_GetObjectItem(sntp, "sync_interval_sec")->valueint;
 
-	    ESP_LOGI("CONFIG", "SNTP: enabled=%d, server_ip=%s, interval=%d",
-	             global_sntp_config.enabled,
-	             global_sntp_config.server_ip,
-	             global_sntp_config.sync_interval_sec);
-	}
+            ESP_LOGI("CONFIG", "SNTP: enabled=%d, server_ip=%s, interval=%d",
+                     global_sntp_config.enabled,
+                     global_sntp_config.server_ip,
+                     global_sntp_config.sync_interval_sec);
+        }
+
+    cJSON *ip_prof = cJSON_GetObjectItem(root, "ip_profile");
+    if (ip_prof) {
+        cJSON *ip1 = cJSON_GetObjectItem(ip_prof, "ip1");
+        if (ip1) {
+            global_ip_profiles[0].client = cJSON_GetObjectItem(ip1, "client")->valueint;
+            strcpy(global_ip_profiles[0].address, cJSON_GetObjectItem(ip1, "address")->valuestring);
+            global_ip_profiles[0].port = cJSON_GetObjectItem(ip1, "port")->valueint;
+            strcpy(global_ip_profiles[0].transport, cJSON_GetObjectItem(ip1, "transport")->valuestring);
+        }
+        cJSON *ip2 = cJSON_GetObjectItem(ip_prof, "ip2");
+        if (ip2) {
+            global_ip_profiles[1].client = cJSON_GetObjectItem(ip2, "client")->valueint;
+            strcpy(global_ip_profiles[1].address, cJSON_GetObjectItem(ip2, "address")->valuestring);
+            global_ip_profiles[1].port = cJSON_GetObjectItem(ip2, "port")->valueint;
+            strcpy(global_ip_profiles[1].transport, cJSON_GetObjectItem(ip2, "transport")->valuestring);
+        }
+    }
+
+    cJSON *mqtt_prof = cJSON_GetObjectItem(root, "mqtt_profile");
+    if (mqtt_prof) {
+        cJSON *mq1 = cJSON_GetObjectItem(mqtt_prof, "mqtt1");
+        if (mq1) {
+            strcpy(global_mqtt_profiles[0].tx_topic, cJSON_GetObjectItem(mq1, "tx_topic")->valuestring);
+            strcpy(global_mqtt_profiles[0].rx_topic, cJSON_GetObjectItem(mq1, "rx_topic")->valuestring);
+        }
+        cJSON *mq2 = cJSON_GetObjectItem(mqtt_prof, "mqtt2");
+        if (mq2) {
+            strcpy(global_mqtt_profiles[1].tx_topic, cJSON_GetObjectItem(mq2, "tx_topic")->valuestring);
+            strcpy(global_mqtt_profiles[1].rx_topic, cJSON_GetObjectItem(mq2, "rx_topic")->valuestring);
+        }
+    }
+
+    cJSON *routing = cJSON_GetObjectItem(root, "routing");
+    if (routing) {
+        cJSON *gw = cJSON_GetObjectItem(routing, "gateway");
+        if (gw) {
+            cJSON *u1 = cJSON_GetObjectItem(gw, "uart1");
+            if (u1) {
+                strcpy(global_routing_config.gateway[0].intf, cJSON_GetObjectItem(u1, "intf")->valuestring);
+                cJSON *p = cJSON_GetObjectItem(u1, "profile");
+                strcpy(global_routing_config.gateway[0].profile, p ? p->valuestring : "");
+            }
+            cJSON *u2 = cJSON_GetObjectItem(gw, "uart2");
+            if (u2) {
+                strcpy(global_routing_config.gateway[1].intf, cJSON_GetObjectItem(u2, "intf")->valuestring);
+                cJSON *p = cJSON_GetObjectItem(u2, "profile");
+                strcpy(global_routing_config.gateway[1].profile, p ? p->valuestring : "");
+            }
+        }
+        cJSON *mon = cJSON_GetObjectItem(routing, "monitor");
+        if (mon) {
+            cJSON *u1 = cJSON_GetObjectItem(mon, "uart1");
+            if (u1) {
+                strcpy(global_routing_config.monitor[0].intf, cJSON_GetObjectItem(u1, "intf")->valuestring);
+                cJSON *p = cJSON_GetObjectItem(u1, "profile");
+                strcpy(global_routing_config.monitor[0].profile, p ? p->valuestring : "");
+            }
+            cJSON *u2 = cJSON_GetObjectItem(mon, "uart2");
+            if (u2) {
+                strcpy(global_routing_config.monitor[1].intf, cJSON_GetObjectItem(u2, "intf")->valuestring);
+                cJSON *p = cJSON_GetObjectItem(u2, "profile");
+                strcpy(global_routing_config.monitor[1].profile, p ? p->valuestring : "");
+            }
+        }
+    }
 
     cJSON_Delete(root);
     free(data);

--- a/firmware/components/um1_http_server/um1_http_server.c
+++ b/firmware/components/um1_http_server/um1_http_server.c
@@ -277,11 +277,8 @@ esp_err_t config_save_handler(httpd_req_t *req)
 
     cJSON *item = NULL;
     cJSON_ArrayForEach(item, incoming) {
-    	cJSON *item = NULL;
-    	cJSON_ArrayForEach(item, incoming) {
-    	    cJSON_DeleteItemFromObject(root, item->string);
-    	    cJSON_AddItemToObject(root, item->string, cJSON_Duplicate(item, 1));
-    	}
+        cJSON_DeleteItemFromObject(root, item->string);
+        cJSON_AddItemToObject(root, item->string, cJSON_Duplicate(item, 1));
     }
 
     char *out = cJSON_Print(root);

--- a/web/src/config.json
+++ b/web/src/config.json
@@ -90,5 +90,15 @@
       "tx_topic": "uart/tx2",
       "rx_topic": "uart/rx2"
     }
+  },
+  "routing": {
+    "gateway": {
+      "uart1": { "intf": "uart2", "profile": "ip1" },
+      "uart2": { "intf": "uart1", "profile": "ip1" }
+    },
+    "monitor": {
+      "uart1": { "intf": "lan", "profile": "ip1" },
+      "uart2": { "intf": "lan", "profile": "ip1" }
+    }
   }
 }

--- a/web/src/gateway/gateway.html
+++ b/web/src/gateway/gateway.html
@@ -102,6 +102,18 @@
       </table>
       <pre id="route_info" class="infographic" aria-label="Инфографика маршрутизации" tabindex="0"></pre>
     </div>
+    <div class="btn-row" style="margin-top:16px;">
+      <button id="save_routes_btn">Сохранить</button>
+      <div class="spacer"></div>
+      <button onclick="sendReboot()">Перезагрузить МК</button>
+    </div>
+  </div>
+  <div id="reboot_overlay" class="overlay">
+    <div class="overlay-card">
+      <h3>Перезагрузка устройства…</h3>
+      <progress id="rb_progress" max="100" value="0"></progress>
+      <div id="rb_status" style="margin-top:8px">Ожидаем повторного подключения…</div>
+    </div>
   </div>
   <script src="/app.js"></script>
   <script src="/gateway/gateway.js"></script>

--- a/web/src/gateway/gateway.js
+++ b/web/src/gateway/gateway.js
@@ -1,3 +1,64 @@
+function showNotification(message, isError=false){
+  const n=document.getElementById('notif');
+  if(!n) return;
+  n.textContent=message;
+  n.className='notification'+(isError?' error':' success');
+  n.style.display='block';
+  setTimeout(()=>n.style.display='none',3000);
+}
+
+function showRebootOverlay(show){
+  const o=document.getElementById('reboot_overlay');
+  if(o) o.style.display=show?'flex':'none';
+}
+
+function setRebootProgress(p,text){
+  const bar=document.getElementById('rb_progress');
+  const st=document.getElementById('rb_status');
+  if(bar) bar.value=Math.max(0,Math.min(100,p|0));
+  if(st && text) st.textContent=text;
+}
+
+function fetchWithTimeout(url,{timeout=1000,...opts}={}){
+  const ctl=new AbortController();
+  const id=setTimeout(()=>ctl.abort(),timeout);
+  return fetch(url,{...opts,signal:ctl.signal,cache:'no-store'}).finally(()=>clearTimeout(id));
+}
+
+async function waitForDevice({estimateMs=25000,timeoutMs=60000,intervalMs=1000}={}){
+  const t0=Date.now();
+  while(Date.now()-t0<timeoutMs){
+    const elapsed=Date.now()-t0;
+    const pct=Math.min(100,Math.round((elapsed/estimateMs)*100));
+    setRebootProgress(pct);
+    try{
+      const r=await fetchWithTimeout('/api/system_info',{timeout:1200});
+      if(r.ok) return true;
+    }catch(_){ }
+    await new Promise(r=>setTimeout(r,intervalMs));
+  }
+  return false;
+}
+
+async function sendReboot(){
+  showRebootOverlay(true);
+  setRebootProgress(5,'Отправляем команду перезагрузки…');
+  try{
+    const resp=await fetch('/reboot');
+    if(!resp.ok) throw new Error('HTTP '+resp.status);
+    setRebootProgress(15,'Контроллер уходит в перезагрузку…');
+    const up=await waitForDevice({estimateMs:25000,timeoutMs:60000});
+    if(up){
+      setRebootProgress(100,'Готово! Перезагружаем страницу…');
+      setTimeout(()=>location.reload(),800);
+    }else{
+      setRebootProgress(100,'⏱ Не дождались. Обновите страницу вручную.');
+    }
+  }catch(err){
+    setRebootProgress(0,'❌ Ошибка: '+err.message);
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const toggles = [
     { intf: 'gw_uart1_intf', profile: 'gw_uart1_profile' },
@@ -69,8 +130,58 @@ document.addEventListener('DOMContentLoaded', () => {
     update();
   });
 
+  function saveRoutes(){
+    const routing={
+      gateway:{
+        uart1:{intf:document.getElementById('gw_uart1_intf').value, profile:document.getElementById('gw_uart1_profile').value},
+        uart2:{intf:document.getElementById('gw_uart2_intf').value, profile:document.getElementById('gw_uart2_profile').value}
+      },
+      monitor:{
+        uart1:{intf:document.getElementById('mon_uart1_intf').value, profile:document.getElementById('mon_uart1_profile').value},
+        uart2:{intf:document.getElementById('mon_uart2_intf').value, profile:document.getElementById('mon_uart2_profile').value}
+      }
+    };
+    fetch('/config',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({routing})})
+      .then(r=>{if(r.ok)showNotification('✅ Маршруты сохранены');else showNotification('❌ Ошибка сохранения',true);})
+      .catch(_=>showNotification('❌ Ошибка соединения',true));
+  }
+
+  document.getElementById('save_routes_btn')?.addEventListener('click',saveRoutes);
+
   fetch('/config.json')
-    .then(r => r.json())
-    .then(data => { cfg = data; render(); })
-    .catch(() => {});
+    .then(r=>r.json())
+    .then(data=>{
+      cfg=data;
+      if(cfg.routing){
+        const r=cfg.routing;
+        if(r.gateway){
+          if(r.gateway.uart1){
+            document.getElementById('gw_uart1_intf').value=r.gateway.uart1.intf;
+            document.getElementById('gw_uart1_profile').value=r.gateway.uart1.profile||'ip1';
+          }
+          if(r.gateway.uart2){
+            document.getElementById('gw_uart2_intf').value=r.gateway.uart2.intf;
+            document.getElementById('gw_uart2_profile').value=r.gateway.uart2.profile||'ip1';
+          }
+        }
+        if(r.monitor){
+          if(r.monitor.uart1){
+            document.getElementById('mon_uart1_intf').value=r.monitor.uart1.intf;
+            document.getElementById('mon_uart1_profile').value=r.monitor.uart1.profile||'ip1';
+          }
+          if(r.monitor.uart2){
+            document.getElementById('mon_uart2_intf').value=r.monitor.uart2.intf;
+            document.getElementById('mon_uart2_profile').value=r.monitor.uart2.profile||'ip1';
+          }
+        }
+      }
+      // adjust disabled states
+      ['gw_uart1','gw_uart2','mon_uart1','mon_uart2'].forEach(p=>{
+        const intf=document.getElementById(p+'_intf');
+        const profile=document.getElementById(p+'_profile');
+        profile.disabled=intf.value==='uart1'||intf.value==='uart2';
+      });
+      render();
+    })
+    .catch(()=>{});
 });


### PR DESCRIPTION
## Summary
- allow editing and storing gateway/monitor routing from web UI
- add MCU reboot button on gateway page
- persist IP/MQTT profiles and new routing options in firmware config

## Testing
- `npm test` *(fails: Could not read package.json)*
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de451184c8329802b543194187432