### PR TITLE
feat: add hex uart commands and gate logging

### DIFF
--- a/firmware/components/um1_http_server/include/um1_http_server.h
+++ b/firmware/components/um1_http_server/include/um1_http_server.h
@@ -58,6 +58,7 @@ esp_err_t ota_update_handler(httpd_req_t *req);
 esp_err_t spiffs_get_handler(httpd_req_t *req);
 esp_err_t ws_control_handler(httpd_req_t *req);
 void send_uart_ws_data(int uart_port, const uint8_t *data, size_t len);
+void send_ws_log(int uart_port, const char *msg);
 esp_err_t reboot_handler(httpd_req_t *req);
 esp_err_t stream_status_handler(httpd_req_t *req);
 httpd_handle_t start_webserver(void);

--- a/firmware/components/um1_http_server/um1_http_server.c
+++ b/firmware/components/um1_http_server/um1_http_server.c
@@ -10,6 +10,8 @@ static int ota_ws_fd = -1;
 
 static const char *TAG = "http_server";
 
+void send_ws_log(int uart_port, const char *msg);
+
 httpd_uri_t login = {
     .uri      = "/login",
     .method   = HTTP_POST,
@@ -510,15 +512,36 @@ esp_err_t ws_control_handler(httpd_req_t *req) {
         return ESP_OK;
     }
 
-    httpd_ws_frame_t ws_pkt = { .type = HTTPD_WS_TYPE_TEXT };
+    httpd_ws_frame_t ws_pkt = {};
     esp_err_t ret = httpd_ws_recv_frame(req, &ws_pkt, 0);
     if (ret != ESP_OK || ws_pkt.len == 0) return ret;
 
-    uint8_t *buf = calloc(1, ws_pkt.len + 1);
+    uint8_t *buf = malloc(ws_pkt.len);
+    if (!buf) return ESP_ERR_NO_MEM;
     ws_pkt.payload = buf;
     ret = httpd_ws_recv_frame(req, &ws_pkt, ws_pkt.len);
     if (ret != ESP_OK) { free(buf); return ret; }
 
+    if (ws_pkt.type == HTTPD_WS_TYPE_BINARY) {
+        if (ws_pkt.len < 1) { free(buf); return ESP_OK; }
+        uint8_t mask = buf[0];
+        const uint8_t *data = buf + 1;
+        size_t dlen = ws_pkt.len - 1;
+        if (mask & 0x1) {
+            uart_write_bytes(UART_PORT_NUM_1, (const char*)data, dlen);
+            uart_wait_tx_done(UART_PORT_NUM_1, portMAX_DELAY);
+            send_ws_log(UART_PORT_NUM_1, "[COMMAND] -> [UART1]");
+        }
+        if (mask & 0x2) {
+            uart_write_bytes(UART_PORT_NUM_2, (const char*)data, dlen);
+            uart_wait_tx_done(UART_PORT_NUM_2, portMAX_DELAY);
+            send_ws_log(UART_PORT_NUM_2, "[COMMAND] -> [UART2]");
+        }
+        free(buf);
+        return ESP_OK;
+    }
+
+    buf[ws_pkt.len] = 0;
     ESP_LOGI(TAG, "Received message: %s", buf);
     int fd = httpd_req_to_sockfd(req);
 
@@ -601,6 +624,23 @@ void send_uart_ws_data(int uart_port, const uint8_t *data, size_t len) {
         };
 
         extern httpd_handle_t global_http_server;
+        if (global_http_server) {
+            httpd_ws_send_frame_async(global_http_server, subscribers[i].fd, &ws_pkt);
+        }
+    }
+}
+
+void send_ws_log(int uart_port, const char *msg) {
+    for (size_t i = 0; i < subs_count; ++i) {
+        bool enabled = (uart_port == UART_PORT_NUM_1) ? subscribers[i].uart1 : subscribers[i].uart2;
+        if (!enabled) continue;
+
+        httpd_ws_frame_t ws_pkt = {
+            .payload = (uint8_t *)msg,
+            .len = strlen(msg),
+            .type = HTTPD_WS_TYPE_TEXT
+        };
+
         if (global_http_server) {
             httpd_ws_send_frame_async(global_http_server, subscribers[i].fd, &ws_pkt);
         }

--- a/firmware/components/um1_router/um1_router.c
+++ b/firmware/components/um1_router/um1_router.c
@@ -1,6 +1,19 @@
 #include "um1_router.h"
+#include "um1_http_server.h"
 
 static const char *TAG = "um1_router";
+
+static const char* ifc_name(if_t ifc) {
+    switch (ifc) {
+        case IF_LAN: return "LAN";
+        case IF_AP:  return "AP";
+        case IF_STA: return "STA";
+        case IF_UART1: return "UART1";
+        case IF_UART2: return "UART2";
+        case IF_MQTT: return "MQTT";
+        default: return "?";
+    }
+}
 
 typedef enum { IF_NONE=0, IF_UART1, IF_UART2, IF_LAN, IF_AP, IF_STA, IF_MQTT } if_t;
 typedef enum { TP_NONE=0, TP_TCP, TP_UDP } tp_t;
@@ -280,14 +293,26 @@ void router_on_uart_rx(int uart_port, const uint8_t *data, size_t len){
         case IF_UART2:{
             int other = (ctx->gate.uart_port==2)?2:1;
             gate_send_uart(other, data, len);
+            char msg[128];
+            snprintf(msg, sizeof(msg), "[UART%d]->[UART%d]", uart_port, other);
+            send_ws_log(uart_port, msg);
         }break;
         case IF_LAN:
         case IF_AP:
         case IF_STA:{
             gate_send_ip(ctx, data, len);
+            char msg[128];
+            snprintf(msg, sizeof(msg), "[UART%d]->[%s][%s][%d][%s]",
+                     uart_port, ifc_name(ctx->gate.ifc), ctx->gate.ip.addr,
+                     ctx->gate.ip.port,
+                     ctx->gate.ip.tp==TP_TCP?"TCP":"UDP");
+            send_ws_log(uart_port, msg);
         }break;
         case IF_MQTT:{
             gate_send_mqtt(ctx, data, len);
+            char msg[64];
+            snprintf(msg, sizeof(msg), "[UART%d]->[MQTT]", uart_port);
+            send_ws_log(uart_port, msg);
         }break;
         default: break;
     }
@@ -298,7 +323,11 @@ void router_on_mqtt_message(const char *topic, const uint8_t *data, size_t len){
     for (int i=0;i<2;i++){
         rt_ctx_t *ctx=&g_ctx[i];
         if (ctx->gate.ifc==IF_MQTT && ctx->gate.rx_topic[0] && strcmp(topic, ctx->gate.rx_topic)==0){
-            gate_send_uart(i==1?2:1, data, len);
+            int u = i==1?2:1;
+            gate_send_uart(u, data, len);
+            char msg[64];
+            snprintf(msg, sizeof(msg), "[MQTT]->[UART%d]", u);
+            send_ws_log(u, msg);
             mon_tee_matching(ctx, data, len);
         }
     }
@@ -421,7 +450,13 @@ static void gate_tcp_client_task(void *pv){
             for(;;){
                 ssize_t n = recv(s,buf,sizeof(buf),0);
                 if (n<=0) break;
-                gate_send_uart((&g_ctx[0]==ctx)?1:2, buf, n);
+                int u = (&g_ctx[0]==ctx)?1:2;
+                gate_send_uart(u, buf, n);
+                char msg[128];
+                snprintf(msg, sizeof(msg), "[%s][%s][%d][TCP]->[UART%d]",
+                         ifc_name(ctx->gate.ifc), ctx->gate.ip.addr,
+                         ctx->gate.ip.port, u);
+                send_ws_log(u, msg);
                 mon_tee_matching(ctx, buf, n);
             }
         } else {
@@ -473,11 +508,20 @@ static void gate_tcp_server_task(void *pv){
             ctx->gate_ip_srv.client_fd = c;
             ESP_LOGI(TAG, "GATE TCP-Server: client connected from %s:%d",
                      inet_ntoa(ca.sin_addr), ntohs(ca.sin_port));
+            char ip[16];
+            strncpy(ip, inet_ntoa(ca.sin_addr), sizeof(ip)-1);
+            ip[sizeof(ip)-1] = '\0';
+            int rport = ntohs(ca.sin_port);
             uint8_t buf[1024];
             for(;;){
                 ssize_t n = recv(c,buf,sizeof(buf),0);
                 if (n<=0) break;
-                gate_send_uart((&g_ctx[0]==ctx)?1:2, buf, n);
+                int u = (&g_ctx[0]==ctx)?1:2;
+                gate_send_uart(u, buf, n);
+                char msg[128];
+                snprintf(msg, sizeof(msg), "[%s][%s][%d][TCP]->[UART%d]",
+                         ifc_name(ctx->gate.ifc), ip, rport, u);
+                send_ws_log(u, msg);
                 mon_tee_matching(ctx, buf, n);
             }
             shutdown(c,SHUT_RDWR); close(c); ctx->gate_ip_srv.client_fd=-1;
@@ -506,7 +550,16 @@ static void gate_udp_client_task(void *pv){
             struct sockaddr_in from; socklen_t fl=sizeof(from);
             ssize_t n = recvfrom(s, buf, sizeof(buf), 0, (struct sockaddr*)&from, &fl);
             if (n>0){
-                gate_send_uart((&g_ctx[0]==ctx)?1:2, buf, n);
+                int u = (&g_ctx[0]==ctx)?1:2;
+                gate_send_uart(u, buf, n);
+                char ip[16];
+                strncpy(ip, inet_ntoa(from.sin_addr), sizeof(ip)-1);
+                ip[sizeof(ip)-1] = '\0';
+                int rport = ntohs(from.sin_port);
+                char msg[128];
+                snprintf(msg, sizeof(msg), "[%s][%s][%d][UDP]->[UART%d]",
+                         ifc_name(ctx->gate.ifc), ip, rport, u);
+                send_ws_log(u, msg);
                 mon_tee_matching(ctx, buf, n);
             }else{
                 vTaskDelay(pdMS_TO_TICKS(5));
@@ -553,7 +606,16 @@ static void gate_udp_server_task(void *pv){
                 if(!known && ctx->gate_udp.udp_peer_cnt<sizeof(ctx->gate_udp.udp_peers)/sizeof(ctx->gate_udp.udp_peers[0])){
                     ctx->gate_udp.udp_peers[ctx->gate_udp.udp_peer_cnt++] = from;
                 }
-                gate_send_uart((&g_ctx[0]==ctx)?1:2, buf, n);
+                int u = (&g_ctx[0]==ctx)?1:2;
+                gate_send_uart(u, buf, n);
+                char ip[16];
+                strncpy(ip, inet_ntoa(from.sin_addr), sizeof(ip)-1);
+                ip[sizeof(ip)-1] = '\0';
+                int rport = ntohs(from.sin_port);
+                char msg[128];
+                snprintf(msg, sizeof(msg), "[%s][%s][%d][UDP]->[UART%d]",
+                         ifc_name(ctx->gate.ifc), ip, rport, u);
+                send_ws_log(u, msg);
                 mon_tee_matching(ctx, buf, n);
             } else if (n<0) {
                 vTaskDelay(pdMS_TO_TICKS(5));

--- a/web/src/diag/diag.html
+++ b/web/src/diag/diag.html
@@ -35,7 +35,7 @@
     <div id="notif" class="notification"></div>
     <div class="card">
       <div class="cmd-row">
-        <input id="message" type="text" placeholder="Введите команду" />
+        <input id="message" type="text" placeholder="Введите команду" pattern="[0-9A-Fa-f]*" oninput="this.value=this.value.replace(/[^0-9a-fA-F]/g,'')" />
         <button onclick="sendMessage()">Отправить</button>
       </div>
       <div class="btn-row" style="margin-top:16px;">

--- a/web/src/diag/diag.js
+++ b/web/src/diag/diag.js
@@ -54,10 +54,29 @@ function stopStream() {
 }
 
 function sendMessage() {
-  const text = document.getElementById("message").value;
-  if (text.trim() && ws && ws.readyState === WebSocket.OPEN) {
-    ws.send(text);
-    log("📤 Sent: " + text);
+  const text = document.getElementById("message").value.trim();
+  const uart1 = document.getElementById("uart1").checked;
+  const uart2 = document.getElementById("uart2").checked;
+
+  if (!text || !(uart1 || uart2)) return;
+  if (text.length % 2 !== 0) {
+    log("⚠️ Нечётная длина ввода");
+    return;
+  }
+
+  const bytes = text.match(/.{1,2}/g).map(h => parseInt(h, 16));
+  const payload = new Uint8Array(bytes.length + 1);
+  payload[0] = (uart1 ? 1 : 0) | (uart2 ? 2 : 0);
+  payload.set(bytes, 1);
+
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(payload);
+    const targets = [];
+    if (uart1) targets.push("UART1");
+    if (uart2) targets.push("UART2");
+    log(`[COMMAND] -> [${targets.join(" & ")}]`);
+  } else {
+    log("⚠️ WebSocket не подключен");
   }
 }
 


### PR DESCRIPTION
## Summary
- restrict diag command input to hex and send as binary to selected UART ports
- support binary commands on WebSocket server and stream gate direction logs
- show routing direction in gate for UART, network, and MQTT traffic

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad989c2cd08329988feb3f56d29eb1