### PR TITLE
feat: show network interface status in diagnostics

### DIFF
--- a/firmware/components/um1_http_server/CMakeLists.txt
+++ b/firmware/components/um1_http_server/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "um1_http_server.c" "protocol_examples_utils.c"
                     INCLUDE_DIRS "include"
-                    REQUIRES esp_system esp_hw_support esp_timer spi_flash esp_netif esp-tls esp_http_server nvs_flash vfs esp_eth esp_wifi app_update um1_lan um1_uart um1_auth json
+                    REQUIRES esp_system esp_hw_support esp_timer spi_flash esp_netif esp-tls esp_http_server nvs_flash vfs esp_eth esp_wifi app_update um1_lan um1_uart um1_auth um1_router json
                     )

--- a/firmware/components/um1_http_server/include/um1_http_server.h
+++ b/firmware/components/um1_http_server/include/um1_http_server.h
@@ -61,6 +61,7 @@ void send_uart_ws_data(int uart_port, const uint8_t *data, size_t len);
 void send_ws_log(int uart_port, const char *msg);
 esp_err_t reboot_handler(httpd_req_t *req);
 esp_err_t stream_status_handler(httpd_req_t *req);
+esp_err_t netinfo_handler(httpd_req_t *req);
 httpd_handle_t start_webserver(void);
 
 #endif // UM1_LAN_H

--- a/firmware/components/um1_http_server/um1_http_server.c
+++ b/firmware/components/um1_http_server/um1_http_server.c
@@ -1,4 +1,6 @@
 #include "um1_http_server.h"
+#include "um1_router.h"
+#include "esp_netif_ip_addr.h"
 
 #define MAX_SUBSCRIBERS 10
 #define UPLOAD_BUFFER_SIZE  1024
@@ -51,6 +53,13 @@ httpd_uri_t stream_status = {
     .uri      = "/api/stream_status",
     .method   = HTTP_GET,
     .handler  = stream_status_handler,
+    .user_ctx = NULL
+};
+
+httpd_uri_t netinfo = {
+    .uri      = "/api/netinfo",
+    .method   = HTTP_GET,
+    .handler  = netinfo_handler,
     .user_ctx = NULL
 };
 
@@ -180,6 +189,43 @@ esp_err_t system_info_handler(httpd_req_t *req)
     free(out);
     cJSON_Delete(root);
 
+    return ESP_OK;
+}
+
+static cJSON *netif_to_json(esp_netif_t *n) {
+    cJSON *o = cJSON_CreateObject();
+    if (!n) {
+        cJSON_AddBoolToObject(o, "up", false);
+        return o;
+    }
+    cJSON_AddBoolToObject(o, "up", esp_netif_is_netif_up(n));
+    uint8_t mac[6];
+    if (esp_netif_get_mac(n, mac) == ESP_OK) {
+        char mac_str[18];
+        snprintf(mac_str, sizeof(mac_str), "%02X:%02X:%02X:%02X:%02X:%02X",
+                 mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+        cJSON_AddStringToObject(o, "mac", mac_str);
+    }
+    esp_netif_ip_info_t ip;
+    if (esp_netif_get_ip_info(n, &ip) == ESP_OK) {
+        char ip_str[16];
+        esp_ip4addr_ntoa(&ip.ip, ip_str, sizeof(ip_str));
+        cJSON_AddStringToObject(o, "ip", ip_str);
+    }
+    return o;
+}
+
+esp_err_t netinfo_handler(httpd_req_t *req)
+{
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddItemToObject(root, "lan", netif_to_json(router_get_netif_lan()));
+    cJSON_AddItemToObject(root, "sta", netif_to_json(router_get_netif_sta()));
+    cJSON_AddItemToObject(root, "ap",  netif_to_json(router_get_netif_ap()));
+    char *out = cJSON_PrintUnformatted(root);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, out);
+    free(out);
+    cJSON_Delete(root);
     return ESP_OK;
 }
 
@@ -752,6 +798,7 @@ httpd_handle_t start_webserver(void)
         httpd_register_uri_handler(server, &logout);
         httpd_register_uri_handler(server, &change_password);
         httpd_register_uri_handler(server, &system_info);
+        httpd_register_uri_handler(server, &netinfo);
         httpd_register_uri_handler(server, &config_get_uri);
         httpd_register_uri_handler(server, &config_save);
         httpd_register_uri_handler(server, &stream_status);

--- a/web/src/diag/diag.html
+++ b/web/src/diag/diag.html
@@ -34,6 +34,10 @@
   <div class="container">
     <div id="notif" class="notification"></div>
     <div class="card">
+      <h3>Интерфейсы</h3>
+      <div id="ifaces"></div>
+    </div>
+    <div class="card">
       <div class="cmd-row">
         <input id="message" type="text" placeholder="Введите команду" pattern="[0-9A-Fa-f]*" oninput="this.value=this.value.replace(/[^0-9a-fA-F]/g,'')" />
         <button onclick="sendMessage()">Отправить</button>

--- a/web/src/diag/diag.js
+++ b/web/src/diag/diag.js
@@ -2,6 +2,24 @@ const logDiv = document.getElementById("log");
 let ws;
 let pendingReboot = false;
 
+async function loadIfaces() {
+  try {
+    const resp = await fetch('/api/netinfo');
+    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    const data = await resp.json();
+    const box = document.getElementById('ifaces');
+    if (box) {
+      box.innerHTML = ['LAN','STA','AP'].map(name => {
+        const info = data[name.toLowerCase()];
+        if (!info || !info.up) return `<div>${name}: down</div>`;
+        return `<div>${name}: ${info.mac} ${info.ip}</div>`;
+      }).join('');
+    }
+  } catch (err) {
+    console.error('iface load error', err);
+  }
+}
+
 function start_socket() {
   ws = new WebSocket(`ws://${location.host}/ws`);
   ws.onopen = () => log("✅ Соединение открыто");
@@ -141,6 +159,7 @@ async function sendReboot() {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
+  loadIfaces();
   if (!pendingReboot) start_socket();
 });
 


### PR DESCRIPTION
## Summary
- show LAN/STA/AP interface addresses on diagnostics page
- expose `/api/netinfo` endpoint with MAC and IP for LAN, STA and AP
- link HTTP server component with router to access netifs

## Testing
- `idf.py build` *(fails: command not found: idf.py)*

------
https://chatgpt.com/codex/tasks/task_e_68af0b28a7ec8329bf8ecc94582da555