### PR TITLE
feat: redesign diagnostics and unify layout

### DIFF
--- a/web/src/about/about.html
+++ b/web/src/about/about.html
@@ -33,8 +33,10 @@
   </header>
   <div class="container">
     <div id="notif" class="notification"></div>
+    <div class="page-header">
+      <h2>О системе</h2>
+    </div>
     <div class="card">
-      <h2>Информация о системе</h2>
       <div id="sysinfo">Загрузка...</div>
     </div>
   </div>

--- a/web/src/diag/diag.html
+++ b/web/src/diag/diag.html
@@ -1,23 +1,20 @@
 <!doctype html>
-
-<script>
-(function(){
-  try{
-    var t = localStorage.getItem('um1_theme');
-    if(!t && window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches){ t='light'; }
-    if(!t) t='dark';
-    document.documentElement.classList.add(t === 'light' ? 'theme-light' : 'theme-dark');
-  }catch(e){}
-})();
-</script>
-<link rel="stylesheet" href="/style.css" />
-
 <html lang="ru">
 <head>
   <meta charset="UTF-8" />
   <title>Диагностика — УМ1</title>
   <link rel="icon" type="image/png" href="/favicon.png" />
   <link rel="stylesheet" href="/style.css" />
+  <script>
+    (function(){
+      try{
+        var t = localStorage.getItem('um1_theme');
+        if(!t && window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches){ t='light'; }
+        if(!t) t='dark';
+        document.documentElement.classList.add(t === 'light' ? 'theme-light' : 'theme-dark');
+      }catch(e){}
+    })();
+  </script>
 </head>
 <body>
   <header>
@@ -33,28 +30,38 @@
   </header>
   <div class="container">
     <div id="notif" class="notification"></div>
-    <div class="card">
-      <h3>Интерфейсы</h3>
-      <div id="ifaces"></div>
+    <div class="page-header">
+      <h2>Диагностика</h2>
+      <button id="copy_btn" class="secondary">Скопировать сводку</button>
     </div>
-    <div class="card">
-      <div class="cmd-row">
-        <input id="message" type="text" placeholder="Введите команду" pattern="[0-9A-Fa-f]*" oninput="this.value=this.value.replace(/[^0-9a-fA-F]/g,'')" />
-        <button onclick="sendMessage()">Отправить</button>
-      </div>
-      <div class="btn-row" style="margin-top:16px;">
-        <button onclick="sendReboot()">Перезагрузить МК</button>
-        <div class="spacer"></div>
-        <button onclick="startStream()">Начать стрим</button>
-        <button onclick="stopStream()">Остановить стрим</button>
-        <button onclick="clearLog()">Очистить лог</button>
-      </div>
-      <div class="check-row" style="margin-top:16px;">
-        <label><input type="checkbox" id="uart1" /> uart1</label>
-        <label><input type="checkbox" id="uart2" /> uart2</label>
-      </div>
+    <div id="summary" class="summary-row">
+      <span id="uptime">Время работы: —</span>
+      <span id="firmware">Прошивка: —</span>
+      <span id="cpu">CPU: —</span>
+      <span id="heap">Свободная память: —</span>
     </div>
-    <div id="log" class="stream-output"></div>
+    <div id="ifaces" class="iface-grid"></div>
+    <div class="diag-main">
+      <div class="card">
+        <h3>UART stream/commands</h3>
+        <div class="cmd-row">
+          <input id="message" type="text" placeholder="Введите команду" pattern="[0-9A-Fa-f]*" oninput="this.value=this.value.replace(/[^0-9a-fA-F]/g,'')" />
+          <button onclick="sendMessage()">Отправить</button>
+        </div>
+        <div class="btn-row" style="margin-top:16px;">
+          <button onclick="sendReboot()">Перезагрузить МК</button>
+          <div class="spacer"></div>
+          <button onclick="startStream()">Начать стрим</button>
+          <button onclick="stopStream()">Остановить стрим</button>
+          <button onclick="clearLog()">Очистить лог</button>
+        </div>
+        <div class="check-row" style="margin-top:16px;">
+          <label><input type="checkbox" id="uart1" /> uart1</label>
+          <label><input type="checkbox" id="uart2" /> uart2</label>
+        </div>
+      </div>
+      <div id="log" class="card log-card"></div>
+    </div>
   </div>
   <div id="reboot_overlay" class="overlay">
     <div class="overlay-card">

--- a/web/src/diag/diag.js
+++ b/web/src/diag/diag.js
@@ -1,99 +1,165 @@
-const logDiv = document.getElementById("log");
+const logDiv = document.getElementById('log');
 let ws;
 let pendingReboot = false;
+const summaryData = {};
 
-async function loadIfaces() {
-  try {
-    const resp = await fetch('/api/netinfo');
-    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+function formatUptime(ms){
+  if(!ms) return '—';
+  let s = Math.floor(ms/1000);
+  const d = Math.floor(s/86400); s%=86400;
+  const h = Math.floor(s/3600); s%=3600;
+  const m = Math.floor(s/60); s%=60;
+  const parts=[];
+  if(d) parts.push(d+'д');
+  if(h) parts.push(h+'ч');
+  if(m) parts.push(m+'м');
+  parts.push(s+'с');
+  return parts.join(' ');
+}
+
+async function loadSummary(){
+  try{
+    const resp = await fetch('/api/system_info');
+    if(!resp.ok) throw new Error('HTTP '+resp.status);
     const data = await resp.json();
+    summaryData.system = data;
+    document.getElementById('uptime').textContent = 'Время работы: '+formatUptime(data.uptime_ms);
+    document.getElementById('firmware').textContent = 'Прошивка: '+(data.running_partition || '—');
+    document.getElementById('cpu').textContent = 'CPU: '+(data.cpu_freq_mhz ? data.cpu_freq_mhz+' МГц' : '—');
+    document.getElementById('heap').textContent = 'Свободная память: '+(data.free_heap ? Math.round(data.free_heap/1024)+' КБ' : '—');
+  }catch(err){
+    console.error('summary load error', err);
+  }
+}
+
+async function loadIfaces(){
+  try{
+    const resp = await fetch('/api/netinfo');
+    if(!resp.ok) throw new Error('HTTP '+resp.status);
+    const data = await resp.json();
+    summaryData.net = data;
     const box = document.getElementById('ifaces');
-    if (box) {
-      box.innerHTML = ['LAN','STA','AP'].map(name => {
-        const info = data[name.toLowerCase()];
-        if (!info || !info.up) return `<div>${name}: down</div>`;
-        return `<div>${name}: ${info.mac} ${info.ip}</div>`;
-      }).join('');
-    }
-  } catch (err) {
+    box.innerHTML = ['lan','sta','ap'].map(k => {
+      const info = data[k] || {};
+      const title = k.toUpperCase();
+      let rows;
+      if(info.up){
+        rows = `<tr><td>IP</td><td>${info.ip || '-'}</td></tr>`+
+               `<tr><td>MAC</td><td>${info.mac || '-'}</td></tr>`;
+      }else{
+        rows = '<tr><td colspan="2">down</td></tr>';
+      }
+      const actions = `<div class="btn-row" style="margin-top:8px;"><button onclick="renewDHCP('${k}')">Renew DHCP</button><button class="secondary" onclick="openSettings('${k}')">Настройки</button></div>`;
+      return `<div class="card iface-card"><h3>${title}</h3><table>${rows}</table>${actions}</div>`;
+    }).join('');
+  }catch(err){
     console.error('iface load error', err);
   }
 }
 
+function copySummary(){
+  const lines=[];
+  const sys = summaryData.system || {};
+  lines.push('Uptime: '+formatUptime(sys.uptime_ms));
+  lines.push('Firmware: '+(sys.running_partition || '-'));
+  if(sys.cpu_freq_mhz) lines.push('CPU: '+sys.cpu_freq_mhz+' MHz');
+  if(sys.free_heap) lines.push('Free heap: '+sys.free_heap);
+  const net = summaryData.net || {};
+  ['lan','sta','ap'].forEach(k => {
+    const info = net[k];
+    if(info && info.up){
+      lines.push(`${k.toUpperCase()}: IP ${info.ip || '-'} MAC ${info.mac || '-'}`);
+    }else{
+      lines.push(`${k.toUpperCase()}: down`);
+    }
+  });
+  const text = lines.join('\n');
+  navigator.clipboard.writeText(text).then(() => {
+    notify('Техническая сводка скопирована','success');
+  }).catch(() => {
+    notify('Не удалось скопировать','error');
+  });
+}
+
+function openSettings(iface){
+  location.href = '/settings/settings.html#'+iface;
+}
+
+function renewDHCP(iface){
+  fetch(`/api/renew_dhcp?iface=${iface}`).then(() => {
+    notify('Команда отправлена','success');
+  }).catch(err => {
+    console.error(err);
+    notify('Ошибка отправки','error');
+  });
+}
+
 function start_socket() {
   ws = new WebSocket(`ws://${location.host}/ws`);
-  ws.onopen = () => log("✅ Соединение открыто");
+  ws.onopen = () => log('✅ Соединение открыто');
   ws.onmessage = e => log(e.data);
-  ws.onclose = () => log("❌ Соединение закрыто");
-  ws.onerror = err => log("⚠️ Ошибка: " + err);
+  ws.onclose = () => log('❌ Соединение закрыто');
+  ws.onerror = err => log('⚠️ Ошибка: ' + err);
 }
 
 function log(msg) {
-  const line = document.createElement("div");
+  const line = document.createElement('div');
   const text = String(msg);
   const m = text.match(/^(\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:[.,]\d+)?\]|\[\d{2}:\d{2}:\d{2}(?:[.,]\d+)?\]|(?:\d{4}-\d{2}-\d{2} )?\d{2}:\d{2}:\d{2}(?:[.,]\d+)?)/);
-
   if (m) {
     const tsSpan = document.createElement('span');
     tsSpan.textContent = m[1] + ' ';
     tsSpan.className = 'ts';
-
     const msgSpan = document.createElement('span');
     msgSpan.textContent = text.slice(m[1].length).replace(/^\s+/, '');
-
     line.appendChild(tsSpan);
     line.appendChild(msgSpan);
   } else {
     line.textContent = text;
   }
-
   logDiv.appendChild(line);
   logDiv.scrollTop = logDiv.scrollHeight;
 }
 
 function startStream() {
-  const uart1 = document.getElementById("uart1").checked;
-  const uart2 = document.getElementById("uart2").checked;
-  const msg = JSON.stringify({ action: "START_STREAM", uart1, uart2 });
-
+  const uart1 = document.getElementById('uart1').checked;
+  const uart2 = document.getElementById('uart2').checked;
+  const msg = JSON.stringify({ action: 'START_STREAM', uart1, uart2 });
   if (ws && ws.readyState === WebSocket.OPEN) {
     ws.send(msg);
-    log("📤 Sent: " + msg);
+    log('📤 Sent: ' + msg);
   } else {
-    log("⚠️ WebSocket не подключен");
+    log('⚠️ WebSocket не подключен');
   }
 }
 
 function stopStream() {
   if (ws && ws.readyState === WebSocket.OPEN) {
-    ws.send("STOP_STREAM");
-    log("📤 Sent: STOP_STREAM");
+    ws.send('STOP_STREAM');
+    log('📤 Sent: STOP_STREAM');
   }
 }
 
 function sendMessage() {
-  const text = document.getElementById("message").value.trim();
-  const uart1 = document.getElementById("uart1").checked;
-  const uart2 = document.getElementById("uart2").checked;
-
+  const text = document.getElementById('message').value.trim();
+  const uart1 = document.getElementById('uart1').checked;
+  const uart2 = document.getElementById('uart2').checked;
   if (!text || !(uart1 || uart2)) return;
   if (text.length % 2 !== 0) {
-    log("⚠️ Нечётная длина ввода");
+    log('⚠️ Нечётная длина ввода');
     return;
   }
-
   const bytes = text.match(/.{1,2}/g).map(h => parseInt(h, 16));
   const payload = new Uint8Array(bytes.length + 1);
   payload[0] = (uart1 ? 1 : 0) | (uart2 ? 2 : 0);
   payload.set(bytes, 1);
-
   if (ws && ws.readyState === WebSocket.OPEN) {
     ws.send(payload);
     const targets = [];
-    if (uart1) targets.push("UART1");
-    if (uart2) targets.push("UART2");
+    if (uart1) targets.push('UART1');
+    if (uart2) targets.push('UART2');
   } else {
-    log("⚠️ WebSocket не подключен");
+    log('⚠️ WebSocket не подключен');
   }
 }
 
@@ -121,12 +187,10 @@ async function waitForDevice({ estimateMs = 25000, timeoutMs = 60000, intervalMs
     const elapsed = Date.now() - t0;
     const pct = Math.min(100, Math.round((elapsed / estimateMs) * 100));
     setRebootProgress(pct);
-
     try {
       const r = await fetchWithTimeout('/api/system_info', { timeout: 1200 });
       if (r.ok) return true;
     } catch (_) {}
-
     await new Promise(r => setTimeout(r, intervalMs));
   }
   return false;
@@ -136,15 +200,11 @@ async function sendReboot() {
   pendingReboot = true;
   showRebootOverlay(true);
   setRebootProgress(5, 'Отправляем команду перезагрузки…');
-
   try {
     const resp = await fetch('/reboot');
     if (!resp.ok) throw new Error('HTTP ' + resp.status);
-
     setRebootProgress(15, 'Контроллер уходит в перезагрузку…');
-
     const up = await waitForDevice({ estimateMs: 25000, timeoutMs: 60000 });
-
     if (up) {
       setRebootProgress(100, 'Готово! Перезагружаем страницу…');
       setTimeout(() => {
@@ -158,13 +218,13 @@ async function sendReboot() {
   }
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener('DOMContentLoaded', () => {
+  loadSummary();
   loadIfaces();
+  document.getElementById('copy_btn').addEventListener('click', copySummary);
   if (!pendingReboot) start_socket();
 });
 
-function clearLog() {
-  logDiv.innerHTML = "";
+function clearLog(){
+  logDiv.innerHTML = '';
 }
-
-

--- a/web/src/gateway/gateway.html
+++ b/web/src/gateway/gateway.html
@@ -33,6 +33,9 @@
   </header>
   <div class="container">
     <div id="notif" class="notification"></div>
+    <div class="page-header">
+      <h2>Шлюз и мониторинг</h2>
+    </div>
     <div class="card">
       <table class="settings-table">
         <tr>

--- a/web/src/settings/settings.html
+++ b/web/src/settings/settings.html
@@ -34,6 +34,10 @@
 
   <div class="container">
     <div id="notif" class="notification" title="Системные сообщения об успешных действиях и ошибках" aria-live="polite"></div>
+    <div class="page-header">
+      <h2>Настройки</h2>
+    </div>
+
 
     <!-- LAN -->
     <div class="card">

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -452,3 +452,56 @@ body.fullscreen-center {
   border-bottom: 1px solid var(--border);
 }
 
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.summary-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  font-size: 14px;
+}
+
+.iface-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.iface-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.iface-card table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.iface-card td {
+  padding: 2px 0;
+}
+
+.diag-main {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.diag-main .card {
+  flex: 1;
+  min-width: 280px;
+}
+
+.log-card {
+  height: 300px;
+  overflow: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+}

--- a/web/src/update/update.html
+++ b/web/src/update/update.html
@@ -32,8 +32,11 @@
     </nav>
   </header>
   <div class="container">
+    <div id="notif" class="notification"></div>
+    <div class="page-header">
+      <h2>Обновление</h2>
+    </div>
     <div class="card">
-      <h2>📦 Обновление устройства</h2>
       <div class="section">
         <label>Выберите папку <code>update</code> (с firmware.bin и src/):</label><br />
         <input type="file" id="updateFolder" webkitdirectory directory multiple />


### PR DESCRIPTION
## Summary
- restyle diagnostics page with summary, interface cards, and log panel
- add copyable technical summary and DHCP renew actions
- unify page headers across UI sections for consistent design

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b15d816b9083299400da3d36c97eba