### PR TITLE
Add logo image to every web page

### DIFF
--- a/web/src/about/about.html
+++ b/web/src/about/about.html
@@ -21,6 +21,7 @@
 </head>
 <body>
   <header>
+    <img src="/logo.png" alt="Логотип УМ1" class="logo" />
     <h1>УМ1</h1>
     <nav>
       <a href="/gateway/gateway.html">Шлюз и мониторинг</a>

--- a/web/src/diag/diag.html
+++ b/web/src/diag/diag.html
@@ -18,6 +18,7 @@
 </head>
 <body>
   <header>
+    <img src="/logo.png" alt="Логотип УМ1" class="logo" />
     <h1>УМ1</h1>
     <nav>
       <a href="/gateway/gateway.html">Шлюз и мониторинг</a>

--- a/web/src/diagnostics/diag.html
+++ b/web/src/diagnostics/diag.html
@@ -8,6 +8,7 @@
 </head>
 <body>
   <header>
+    <img src="/logo.png" alt="Логотип УМ1" class="logo" />
     <h1>УМ1</h1>
     <nav>
       <a href="/gateway/gateway.html">Шлюз и мониторинг</a>

--- a/web/src/gateway/gateway.html
+++ b/web/src/gateway/gateway.html
@@ -21,6 +21,7 @@
 </head>
 <body>
   <header>
+    <img src="/logo.png" alt="Логотип УМ1" class="logo" />
     <h1>УМ1</h1>
     <nav>
       <a href="/gateway/gateway.html" class="active">Шлюз и мониторинг</a>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -19,6 +19,7 @@
   <title>Перенаправление...</title>
 </head>
 <body>
+  <img src="/logo.png" alt="Логотип УМ1" class="logo logo-centered" />
   <p>Перенаправление на раздел "Шлюз и мониторинг"...</p>
 </body>
 </html>

--- a/web/src/login.html
+++ b/web/src/login.html
@@ -21,6 +21,7 @@
 </head>
 <body class="fullscreen-center">
   <div class="card" style="width:320px;">
+    <img src="/logo.png" alt="Логотип УМ1" class="logo logo-centered" />
     <h2>Вход</h2>
     <div id="notif" class="notification"></div>
     <div class="fld">

--- a/web/src/settings/settings.html
+++ b/web/src/settings/settings.html
@@ -21,6 +21,7 @@
 </head>
 <body>
   <header>
+    <img src="/logo.png" alt="Логотип УМ1" class="logo" />
     <h1 title="Управление устройством УМ1: сеть, Wi-Fi, UART, MQTT, SNTP, маршрутизация и доступ">УМ1</h1>
     <nav>
       <a href="/gateway/gateway.html" title="Шлюзование и мониторинг данных в реальном времени">Шлюз и мониторинг</a>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -107,6 +107,19 @@ header {
   gap: 10px;
 }
 
+.logo {
+  height: 36px;
+  width: auto;
+}
+
+header .logo {
+  flex-shrink: 0;
+}
+
+.logo-centered {
+  display: block;
+  margin: 0 auto 16px;
+}
 header h1 {
   font-size: 18px;
   margin: 0;

--- a/web/src/update/update.html
+++ b/web/src/update/update.html
@@ -21,6 +21,7 @@
 </head>
 <body>
   <header>
+    <img src="/logo.png" alt="Логотип УМ1" class="logo" />
     <h1>УМ1</h1>
     <nav>
       <a href="/gateway/gateway.html">Шлюз и мониторинг</a>


### PR DESCRIPTION
## Summary
- display the shared UM1 logo in each page header and on the login and redirect screens
- add shared styling for inline and centered logo usage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de7e1ac2b08329bbc8d8f130ebe1d3